### PR TITLE
Fix search and sort ordering

### DIFF
--- a/src/pythonfinder/models/__init__.py
+++ b/src/pythonfinder/models/__init__.py
@@ -42,7 +42,7 @@ class BasePath(object):
         found = next((children[(self.path / child).as_posix()] for child in valid_names if (self.path / child).as_posix() in children), None)
         return found
 
-    def find_python_version(self, major, minor=None, patch=None, pre=None, dev=None):
+    def find_python_version(self, major=None, minor=None, patch=None, pre=None, dev=None):
         """Search or self for the specified Python version and return the first match.
 
         :param major: Major version number.
@@ -55,21 +55,21 @@ class BasePath(object):
         """
 
         version_matcher = operator.methodcaller(
-            "matches", major, minor=minor, patch=patch, pre=pre, dev=dev
+            "matches", major=major, minor=minor, patch=patch, pre=pre, dev=dev
         )
         is_py = operator.attrgetter("is_python")
         py_version = operator.attrgetter("as_python")
         if not self.is_dir:
-            if self.is_python and self.as_python.matches(major, minor=minor, patch=patch, pre=pre, dev=dev):
+            if self.is_python and self.as_python.matches(major=major, minor=minor, patch=patch, pre=pre, dev=dev):
                 return self
             return
         finder = ((child, child.as_python) for child in self.children.values() if child.is_python and child.as_python)
         py_filter = filter(
             None, filter(lambda child: version_matcher(child[1]), finder)
         )
-        version_sort = operator.attrgetter("version")
+        version_sort = operator.attrgetter("version_sort")
         return next(
-            (c[0] for c in sorted(py_filter, key=lambda child: child[1].version, reverse=True)), None
+            (c[0] for c in sorted(py_filter, key=lambda child: child[1].version_sort, reverse=True)), None
         )
 
 

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -151,7 +151,7 @@ class SystemPath(object):
         filtered = filter(None, (sub_which(self.get_path(k)) for k in self.path_order))
         return next((f for f in filtered), None)
 
-    def find_all_python_versions(self, major, minor=None, patch=None, pre=None, dev=None):
+    def find_all_python_versions(self, major=None, minor=None, patch=None, pre=None, dev=None):
         """Search for a specific python version on the path. Return all copies
 
         :param major: Major python version to search for.
@@ -173,10 +173,10 @@ class SystemPath(object):
                 return windows_finder_version
         paths = (self.get_path(k) for k in self.path_order)
         path_filter = filter(None, (sub_finder(p) for p in paths if p is not None))
-        version_sort = operator.attrgetter("as_python.version")
+        version_sort = operator.attrgetter("as_python.version_sort")
         return [c for c in sorted(path_filter, key=version_sort, reverse=True)]
 
-    def find_python_version(self, major, minor=None, patch=None, pre=None, dev=None):
+    def find_python_version(self, major=None, minor=None, patch=None, pre=None, dev=None):
         """Search for a specific python version on the path.
 
         :param major: Major python version to search for.
@@ -198,7 +198,7 @@ class SystemPath(object):
                 return windows_finder_version
         paths = (self.get_path(k) for k in self.path_order)
         path_filter = filter(None, (sub_finder(p) for p in paths if p is not None))
-        version_sort = operator.attrgetter("as_python.version")
+        version_sort = operator.attrgetter("as_python.version_sort")
         return next(
             (c for c in sorted(path_filter, key=version_sort, reverse=True)), None
         )

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -28,6 +28,30 @@ class PythonVersion(object):
     executable = attr.ib(default=None)
 
     @property
+    def version_sort(self):
+        """version_sort tuple for sorting against other instances of the same class.
+        
+        Returns a tuple of the python version but includes a point for non-dev,
+        and a point for non-prerelease versions.  So released versions will have 2 points
+        for this value.  E.g. `(3, 6, 6, 2)` is a release, `(3, 6, 6, 1)` is a prerelease,
+        `(3, 6, 6, 0)` is a dev release, and `(3, 6, 6, 3)` is a postrelease.
+        """
+        release_sort = 2
+        if self.is_postrelease:
+            release_sort = 3
+        elif self.is_prerelease:
+            release_sort = 1
+        elif self.is_devrelease:
+            release_sort = 0
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+            release_sort
+        )
+
+
+    @property
     def version_tuple(self):
         """Provides a version tuple for using as a dictionary key.
 
@@ -43,9 +67,9 @@ class PythonVersion(object):
             self.is_devrelease,
         )
 
-    def matches(self, major, minor=None, patch=None, pre=False, dev=False):
+    def matches(self, major=None, minor=None, patch=None, pre=False, dev=False):
         return (
-            self.major == major
+            (major is None or self.major == major)
             and (minor is None or self.minor == minor)
             and (patch is None or self.patch == patch)
             and (pre is None or self.is_prerelease == pre)
@@ -77,7 +101,7 @@ class PythonVersion(object):
         """
 
         try:
-            version = parse_version(version)
+            version = parse_version(str(version))
         except TypeError:
             raise ValueError("Unable to parse version: %s" % version)
         if not version or not version.release:

--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -50,31 +50,14 @@ class Finder(object):
         return self.system_path.which(exe)
 
     def find_python_version(self, major, minor=None, patch=None, pre=None, dev=None):
-        if (
-            major
-            and not minor
-            and not patch
-            and not pre
-            and not dev
-            and isinstance(major, six.string_types)
-        ):
-            from .models import PythonVersion
-            version_dict = {}
-            if "." in major:
-                version_dict = PythonVersion.parse(major)
-            elif len(major) == 1:
-                version_dict = {
-                    'major': int(major),
-                    'minor': None,
-                    'patch': None,
-                    'is_prerelease': False,
-                    'is_devrelease': False
-                }
+        from .models import PythonVersion
+        if isinstance(major, six.string_types) and pre is None and minor is None and dev is None and patch is None:
+            version_dict = PythonVersion.parse(major)
             major = version_dict.get("major", major)
             minor = version_dict.get("minor", minor)
             patch = version_dict.get("patch", patch)
-            pre = version_dict.get("is_prerelease", pre)
-            dev = version_dict.get("is_devrelease", dev)
+            pre = version_dict.get("is_prerelease", pre) if pre is not None else pre
+            dev = version_dict.get("is_devrelease", dev) if dev is not None else dev
         if os.name == "nt":
             match = self.windows_finder.find_python_version(
                 major, minor=minor, patch=patch, pre=pre, dev=dev
@@ -82,5 +65,5 @@ class Finder(object):
             if match:
                 return match
         return self.system_path.find_python_version(
-            major, minor=minor, patch=patch, pre=pre, dev=dev
+            major=major, minor=minor, patch=patch, pre=pre, dev=dev
         )


### PR DESCRIPTION
- Include release status in sort order (fixes #6)
- Allows calls to `finder.system_path.find_all_python_versions()` with
  no args (fixes #5)

Signed-off-by: Dan Ryan <dan@danryan.co>