### PR TITLE
Skip uninstalled Python versions on Windows

### DIFF
--- a/src/pythonfinder/models/windows.py
+++ b/src/pythonfinder/models/windows.py
@@ -60,7 +60,10 @@ class WindowsFinder(BaseFinder):
         env_versions = pep514env.findall()
         path = None
         for version_object in env_versions:
-            path = ensure_path(version_object.info.install_path.__getattr__(""))
+            install_path = getattr(version_object.info, 'install_path', None)
+            if install_path is None:
+                continue
+            path = ensure_path(install_path.__getattr__(""))
             try:
                 py_version = PythonVersion.from_windows_launcher(version_object)
             except InvalidPythonVersion:


### PR DESCRIPTION
When the Python version has been uninstalled the info object simply
does not have an attribute install_path.  In case they ever stop this
conditional attribute setting let's use getattr() with a None default
and check for that to skip.

pypa/pipenv#2397