### PR TITLE
Add flag to ignore unsupported versions

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -91,10 +91,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
-                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
             ],
-            "version": "==2018.8.13"
+            "version": "==2018.8.24"
         },
         "chardet": {
             "hashes": [
@@ -485,10 +485,11 @@
         },
         "vistir": {
             "hashes": [
-                "sha256:d0c5e0a3f0d8684ad7107bd260a7fcfb050a8bc514a95d2d034fc55bc6e80cc2",
-                "sha256:dd60114001c636d72779c3cf985ef0516bd013c65998d183d52cd97fda85bff2"
+                "sha256:06e9d8b26d757e6a5d3a168463023067b3ef2be2793d6a5887f6c4496c82b2b9",
+                "sha256:0c62181f430164764714b7cad4fd5b98f9f34afca36a278b942b99502c2dfb0b"
             ],
-            "version": "==0.1.1"
+            "index": "pypi",
+            "version": "==0.1.7"
         }
     }
 }

--- a/src/pythonfinder/__init__.py
+++ b/src/pythonfinder/__init__.py
@@ -2,6 +2,14 @@ from __future__ import print_function, absolute_import
 
 __version__ = '1.1.1.dev0'
 
+# Add NullHandler to "pythonfinder" logger, because Python2's default root
+# logger has no handler and warnings like this would be reported:
+#
+# > No handlers could be found for logger "pythonfinder.models.pyenv"
+import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
 __all__ = ["Finder", "WindowsFinder", "SystemPath", "InvalidPythonVersion"]
 from .pythonfinder import Finder
 from .models import SystemPath, WindowsFinder

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -37,6 +37,7 @@ class SystemPath(object):
     pyenv_finder = attr.ib(default=None, validator=optional_instance_of("PyenvPath"))
     system = attr.ib(default=False)
     _version_dict = attr.ib(default=attr.Factory(defaultdict))
+    ignore_unsupported = attr.ib(default=False)
 
     __finders = attr.ib(default=attr.Factory(dict))
 
@@ -129,7 +130,7 @@ class SystemPath(object):
             pyenv_index = self.path_order.index(last_pyenv)
         except ValueError:
             return
-        self.pyenv_finder = PyenvFinder.create(root=PYENV_ROOT)
+        self.pyenv_finder = PyenvFinder.create(root=PYENV_ROOT, ignore_unsupported=self.ignore_unsupported)
         # paths = (v.paths.values() for v in self.pyenv_finder.versions.values())
         root_paths = (
             p for path in self.pyenv_finder.expanded_paths for p in path if p.is_root
@@ -268,7 +269,7 @@ class SystemPath(object):
         return ver
 
     @classmethod
-    def create(cls, path=None, system=False, only_python=False, global_search=True):
+    def create(cls, path=None, system=False, only_python=False, global_search=True, ignore_unsupported=False):
         """Create a new :class:`pythonfinder.models.SystemPath` instance.
 
         :param path: Search path to prepend when searching, defaults to None
@@ -277,6 +278,8 @@ class SystemPath(object):
         :param system: bool, optional
         :param only_python: Whether to search only for python executables, defaults to False
         :param only_python: bool, optional
+        :param ignore_unsupported: Whether to ignore unsupported python versions, if False, an error is raised, defaults to True
+        :param ignore_unsupported: bool, optional
         :return: A new :class:`pythonfinder.models.SystemPath` instance.
         :rtype: :class:`pythonfinder.models.SystemPath`
         """
@@ -303,6 +306,7 @@ class SystemPath(object):
             only_python=only_python,
             system=system,
             global_search=global_search,
+            ignore_unsupported=ignore_unsupported,
         )
 
 

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -108,7 +108,7 @@ class PythonVersion(object):
         is_debug = False
         if version.endswith("-debug"):
             is_debug = True
-            version, _, _ = verson.rpartition("-")
+            version, _, _ = version.rpartition("-")
         try:
             version = parse_version(str(version))
         except TypeError:

--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -7,27 +7,30 @@ from .models import SystemPath
 
 
 class Finder(object):
-    def __init__(self, path=None, system=False, global_search=True):
+    def __init__(self, path=None, system=False, global_search=True, ignore_unsupported=False):
         """Finder A cross-platform Finder for locating python and other executables.
-        
+
         Searches for python and other specified binaries starting in `path`, if supplied,
         but searching the bin path of `sys.executable` if `system=True`, and then
         searching in the `os.environ['PATH']` if `global_search=True`.  When `global_search`
         is `False`, this search operation is restricted to the allowed locations of 
         `path` and `system`.
-        
+
         :param path: A bin-directory search location, defaults to None
         :param path: str, optional
         :param system: Whether to include the bin-dir of `sys.executable`, defaults to False
         :param system: bool, optional
         :param global_search: Whether to search the global path from os.environ, defaults to True
         :param global_search: bool, optional
+        :param ignore_unsupported: Whether to ignore unsupported python versions, if False, an error is raised, defaults to True
+        :param ignore_unsupported: bool, optional
         :returns: a :class:`~pythonfinder.pythonfinder.Finder` object.
         """
 
         self.path_prepend = path
         self.global_search = global_search
         self.system = system
+        self.ignore_unsupported = ignore_unsupported
         self._system_path = None
         self._windows_finder = None
 
@@ -38,6 +41,7 @@ class Finder(object):
                 path=self.path_prepend,
                 system=self.system,
                 global_search=self.global_search,
+                ignore_unsupported=self.ignore_unsupported,
             )
         return self._system_path
 


### PR DESCRIPTION
This PR fixes couple minor issues and adds a `Finder(.., ignore_unsupported=True)` flag to enable ignoring invalid/unsupported Python versions. The default behaviour of this library will remain the same so custom pythons like those mentioned in comments to #12 will still not be supported, but enabling this flag in pipenv should help to fix [pipenv errors](https://github.com/pypa/pipenv/issues/2964) for good. 