### PR TITLE
Only try to parse pyenv CPython interpreters

### DIFF
--- a/src/pythonfinder/models/pyenv.py
+++ b/src/pythonfinder/models/pyenv.py
@@ -30,7 +30,7 @@ class PyenvFinder(BaseFinder):
     @versions.default
     def get_versions(self):
         versions = defaultdict(VersionPath)
-        for p in self.root.glob("versions/*"):
+        for p in self.root.glob("versions/[2-3]*"):
             try:
                 version = PythonVersion.parse(p.name)
             except Exception:


### PR DESCRIPTION
`pythonfinder.models.pyenv.PyenvFinder.get_versions` appears to raise an exception when it tries to parse non-CPython interpreter versions from the `pyenv` versions folder.

For example you can install anaconda via `pyenv`, and if installed, the above function will raise a `ValueError`. The value like `anaconda3-5.3.0`. Here's the [full list](https://github.com/pyenv/pyenv/tree/4469d0dff937640ab579265a8f0ae6f295102260/plugins/python-build/share/python-build) of version types that might appear. It's mainly just non-CPython interpreters have their name prepended.

I've made this pull request which limits to only try and parse and return the CPython interpreters. If this project is meant to be returning all Python's, including non-CPython interpreters, then this pull request is not sufficient.