### PR TITLE
use ASDF_DIR env var to test if ASDF is installed

### DIFF
--- a/src/pythonfinder/environment.py
+++ b/src/pythonfinder/environment.py
@@ -7,7 +7,7 @@ import sys
 PYENV_INSTALLED = bool(os.environ.get("PYENV_SHELL")) or bool(
     os.environ.get("PYENV_ROOT")
 )
-ASDF_INSTALLED = bool(os.environ.get("ASDF_DATA_DIR"))
+ASDF_INSTALLED = bool(os.environ.get("ASDF_DIR"))
 PYENV_ROOT = os.path.expanduser(
     os.path.expandvars(os.environ.get("PYENV_ROOT", "~/.pyenv"))
 )


### PR DESCRIPTION
ASDF_DIR can test if ASDF is installed. ASDF_DATA_DIR is (optionally) set by the user so it cannot be used to test if ASDF is installed.