### PR TITLE
Add resilient parsing of python versions

### DIFF
--- a/news/bugfix.40.rst
+++ b/news/bugfix.40.rst
@@ -1,0 +1,1 @@
+Add resilient parsing to look only for ``major.minor(.patch)?`` as a fallback parser and allow more graceful continuation if a path is not a real path to python.

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -8,6 +8,7 @@ from fnmatch import fnmatch
 
 import attr
 import io
+import re
 import six
 
 import vistir
@@ -22,6 +23,9 @@ try:
     from functools import lru_cache
 except ImportError:
     from backports.functools_lru_cache import lru_cache
+
+
+version_re = re.compile(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.?(?P<patch>(?<=\.)[0-9]+)")
 
 
 PYTHON_IMPLEMENTATIONS = (
@@ -46,18 +50,26 @@ for rule in RULES:
     )
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def get_python_version(path):
     """Get python version string using subprocess from a given path."""
     version_cmd = [path, "-c", "import sys; print(sys.version.split()[0])"]
     try:
         c = vistir.misc.run(version_cmd, block=True, nospin=True, return_object=True,
-                                combine_stderr=False)
+                            combine_stderr=False, write_to_stdout=False)
     except OSError:
         raise InvalidPythonVersion("%s is not a valid python path" % path)
     if not c.out:
         raise InvalidPythonVersion("%s is not a valid python path" % path)
     return c.out.strip()
+
+
+@lru_cache(maxsize=1024)
+def parse_python_version(version_str):
+    m = version_re.match(version_str)
+    if not m:
+        raise InvalidPythonVersion("%s is not a python version" % version_str)
+    return m.groupdict()
 
 
 def optional_instance_of(cls):

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -152,7 +152,7 @@ def build_docs(ctx):
     if not docs_folder.endswith('/'):
         docs_folder = '{0}/'.format(docs_folder)
     args = ["--ext-autodoc", "--ext-viewcode", "-o", docs_folder]
-    args.extend(["-A", "'{{ cookiecutter.author }} <{{ cookiecutter.email }}>'"])
+    args.extend(["-A", "'Dan Ryan <dan@danryan.co>'"])
     args.extend(["-R", _current_version])
     args.extend(["-V", ".".join(minor)])
     args.extend(["-e", "-M", "-F", f"src/{PACKAGE_NAME}"])


### PR DESCRIPTION
Add resilient parsing of python versions

- Use graceful fallbacks on failure to parse versions
- Continue iterating through paths when failures occur
- Fixes #40