### PR TITLE
Return empty list instead of None

### DIFF
--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -151,6 +151,7 @@ def parse_pyenv_version_order(filename="version"):
             contents = fh.read()
         version_order = [v for v in contents.splitlines()]
         return version_order
+    return []
 
 
 def parse_asdf_version_order(filename=".tool-versions"):
@@ -165,6 +166,7 @@ def parse_asdf_version_order(filename=".tool-versions"):
             python_key, _, versions = python_section.partition(" ")
             if versions:
                 return versions.split()
+    return []
 
 
 # TODO: Reimplement in vistir


### PR DESCRIPTION
Closes https://github.com/pypa/pipenv/issues/3247

It is because None can not be iterated in https://github.com/sarugaku/pythonfinder/blob/dd75de89059a245ec81935f87d609472e21295ab/src/pythonfinder/models/python.py#L70 when version order file does not exist 