### PR TITLE
Accept Ubuntu Cosmic's Python version, too.

### DIFF
--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -359,6 +359,10 @@ class PythonVersion(object):
         if version.endswith("-debug"):
             is_debug = True
             version, _, _ = version.rpartition("-")
+        # Hack around the fact that Ubuntu Cosmic ships a "2.7.15+" version.
+        # This is not PEP-440-compliant, but we should better recognize it.
+        if version.endswith("+"):
+            version = version[:-1]
         try:
             version = parse_version(str(version))
         except TypeError:


### PR DESCRIPTION
Without this workaround pythonfinder doesn't crash, but it simply ignores
Ubuntu Cosmic's "2.7.15+" version.  Alas, that version does not conform to
PEP 440, but there is nothing one can do about that.  Nevertheless,
pythonfinder (and consequently pipenv!) should better accept that version,
anyway.  Adding that workaround in pythonfinder seems to be the right place,
making the VERSION_PATTERN regex in packaging's version.py more forgiving
doesn't look right.