### PR TITLE
Fix tests in multiprocess

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def _get_python_versions():
             comes_from_path = getattr(comes_from, "path", v.path)
         else:
             comes_from_path = v.path
-    return list(pythons)
+    return sorted(list(pythons))
 
 
 PYTHON_VERSIONS = _get_python_versions()


### PR DESCRIPTION
One issue is ```PYTHON_VERSIONS``` is not sorted, so each subprocess get different tests.

The other issue I didn't figure out. It looks like pythonfinder will get different result for main process and subprocess. For example, in main process is ```/home/travis/virtualenv/python3.4.6/bin/python3``` but ```/home/travis/virtualenv/python3.4.6/bin/python3.4``` in subprocess (Or swap them, not sure). Similarly, one is ```/usr/bin/python``` while the other one is ```/usr/bin/python2```

```
-tests/test_utils.py::test_is_python[/home/travis/virtualenv/python3.4.6/bin/python3-True]
-tests/test_utils.py::test_is_python[/opt/pyenv/versions/2.7/bin/python-True]
-tests/test_utils.py::test_is_python[/opt/pyenv/versions/3.4.6/bin/python3-True]
+tests/test_utils.py::test_is_python[/home/travis/virtualenv/python3.4.6/bin/python3.4-True]
+tests/test_utils.py::test_is_python[/opt/pyenv/versions/2.7.14/bin/python-True]
+tests/test_utils.py::test_is_python[/opt/pyenv/versions/3.4.6/bin/python-True]
-tests/test_utils.py::test_is_python[/opt/pyenv/versions/3.6/bin/python3.6-True]
-tests/test_utils.py::test_is_python[/opt/pyenv/versions/3.6/bin/python3.6m-True]
-tests/test_utils.py::test_is_python[/usr/bin/python-True]
+tests/test_utils.py::test_is_python[/opt/pyenv/versions/3.6.3/bin/python3.6-True]
+tests/test_utils.py::test_is_python[/opt/pyenv/versions/3.6.3/bin/python3.6m-True]
+tests/test_utils.py::test_is_python[/usr/bin/python2-True]
```