### PR TITLE
Cleanup project settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ matrix:
   fast_finish: true
 
 install:
-  - "pip install --upgrade pip pipenv pytest pytest-cov pytest-timeout --upgrade-strategy=eager"
+  - "pip install --upgrade setuptools pip pipenv --upgrade-strategy=eager"
   - "pipenv install --dev"
-  - "pipenv run pip install --upgrade -e .[tests] pytest pytest-timeout pytest-cov --upgrade-strategy=eager"
 script:
-  - "pipenv run pytest -ra tests/"
+  - "pipenv run pytest"
 
 jobs:
   include:
@@ -25,15 +24,10 @@ jobs:
     - python: "3.4"
     - stage: packaging
       python: "3.6"
-      install:
-        - "pip install --upgrade setuptools twine readme_renderer[md]"
       script:
         - "python setup.py sdist"
         - "twine check dist/*"
     - stage: coverage
       python: "3.6"
-      install:
-        - "pip install --upgrade pip pipenv pytest-cov pytest-timeout pytest"
-        - "pipenv install --dev"
       script:
-        - "pipenv run pytest --timeout 300 --cov=pythonfinder --cov-report=term-missing --cov-report=xml --cov-report=html tests"
+        - "pipenv run pytest --cov=pythonfinder --cov-report=term-missing --cov-report=xml --cov-report=html tests"

--- a/Pipfile
+++ b/Pipfile
@@ -1,26 +1,30 @@
 [packages]
 
 [dev-packages]
-flake8 = "*"
-sphinx-click = "*"
-pytest = "*"
-mock = "*"
-sphinx = "*"
-twine = "*"
-pytest-xdist = "*"
+pythonfinder = {path = ".", editable = true}
 invoke = "*"
 crayons = "*"
-pythonfinder = {path = ".", editable = true}
-sphinx-rtd-theme = "*"
-rope = "*"
-black = {version = "*", markers = "python_version>='3.6'"}
 parver = "*"
 towncrier = "*"
+mock = "*"
+pytest = "*"
+pytest-cov = "*"
+pytest-timeout = "*"
+pytest-xdist = "*"
+sphinx = "*"
+sphinx-click = "*"
+sphinx-rtd-theme = "*"
+sphinx-autodoc-types = "*"
+readme_renderer = {version = "*", extras = ["md"]}
+twine = "*"
+flake8 = "*"
+black = {version = "*", markers = "python_version>='3.6'"}
+isort = "*"
+rope = "*"
 mypy = {version = "*", markers = "python_version>='3.4'"}
 mypy_extensions = "*"
 typed-ast = {version = "*", markers = "python_version>='3.3'"}
 lxml = "*"
-sphinx-autodoc-types = "*"
 
 [scripts]
 black = "python -m black src/pythonfinder"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a91c46d0787c1a3f8f3c58c81075d4c748580cb5dc30635c50ea02d2bbebea41"
+            "sha256": "5e5ee882d5a4ea4316f7363c812c4f08fb238770dd14ae0a9c3a825f72268b10"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -126,6 +126,43 @@
             ],
             "version": "==2018.11.29"
         },
+        "cffi": {
+            "hashes": [
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
+            ],
+            "version": "==1.11.5"
+        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
@@ -140,6 +177,39 @@
             ],
             "version": "==7.0"
         },
+        "cmarkgfm": {
+            "hashes": [
+                "sha256:0186dccca79483e3405217993b83b914ba4559fe9a8396efc4eea56561b74061",
+                "sha256:1a625afc6f62da428df96ec325dc30866cc5781520cbd904ff4ec44cf018171c",
+                "sha256:207b7673ff4e177374c572feeae0e4ef33be620ec9171c08fd22e2b796e03e3d",
+                "sha256:275905bb371a99285c74931700db3f0c078e7603bed383e8cf1a09f3ee05a3de",
+                "sha256:50098f1c4950722521f0671e54139e0edc1837d63c990cf0f3d2c49607bb51a2",
+                "sha256:50ed116d0b60a07df0dc7b180c28569064b9d37d1578d4c9021cff04d725cb63",
+                "sha256:61a72def110eed903cd1848245897bcb80d295cd9d13944d4f9f30cba5b76655",
+                "sha256:64186fb75d973a06df0e6ea12879533b71f6e7ba1ab01ffee7fc3e7534758889",
+                "sha256:665303d34d7f14f10d7b0651082f25ebf7107f29ef3d699490cac16cdc0fc8ce",
+                "sha256:70b18f843aec58e4e64aadce48a897fe7c50426718b7753aaee399e72df64190",
+                "sha256:761ee7b04d1caee2931344ac6bfebf37102ffb203b136b676b0a71a3f0ea3c87",
+                "sha256:811527e9b7280b136734ed6cb6845e5fbccaeaa132ddf45f0246cbe544016957",
+                "sha256:987b0e157f70c72a84f3c2f9ef2d7ab0f26c08f2bf326c12c087ff9eebcb3ff5",
+                "sha256:9fc6a2183d0a9b0974ec7cdcdad42bd78a3be674cc3e65f87dd694419b3b0ab7",
+                "sha256:a3d17ee4ae739fe16f7501a52255c2e287ac817cfd88565b9859f70520afffea",
+                "sha256:ba5b5488719c0f2ced0aa1986376f7baff1a1653a8eb5fdfcf3f84c7ce46ef8d",
+                "sha256:c573ea89dd95d41b6d8cf36799c34b6d5b1eac4aed0212dee0f0a11fb7b01e8f",
+                "sha256:c5f1b9e8592d2c448c44e6bc0d91224b16ea5f8293908b1561de1f6d2d0658b1",
+                "sha256:cbe581456357d8f0674d6a590b1aaf46c11d01dd0a23af147a51a798c3818034",
+                "sha256:cf219bec69e601fe27e3974b7307d2f06082ab385d42752738ad2eb630a47d65",
+                "sha256:cf5014eb214d814a83a7a47407272d5db10b719dbeaf4d3cfe5969309d0fcf4b",
+                "sha256:d08bad67fa18f7e8ff738c090628ee0cbf0505d74a991c848d6d04abfe67b697",
+                "sha256:d6f716d7b1182bf35862b5065112f933f43dd1aa4f8097c9bcfb246f71528a34",
+                "sha256:e08e479102627641c7cb4ece421c6ed4124820b1758765db32201136762282d9",
+                "sha256:e20ac21418af0298437d29599f7851915497ce9f2866bc8e86b084d8911ee061",
+                "sha256:e25f53c37e319241b9a412382140dffac98ca756ba8f360ac7ab5e30cad9670a",
+                "sha256:e8932bddf159064f04e946fbb64693753488de21586f20e840b3be51745c8c09",
+                "sha256:f20900f16377f2109783ae9348d34bc80530808439591c3d3df73d5c7ef1a00c"
+            ],
+            "version": "==0.4.2"
+        },
         "colorama": {
             "hashes": [
                 "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
@@ -153,6 +223,40 @@
             ],
             "markers": "python_version < '3.2'",
             "version": "==3.5.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:029c69deaeeeae1b15bc6c59f0ffa28aa8473721c614a23f2c2976dec245cd12",
+                "sha256:02abbbebc6e9d5abe13cd28b5e963dedb6ffb51c146c916d17b18f141acd9947",
+                "sha256:1bbfe5b82a3921d285e999c6d256c1e16b31c554c29da62d326f86c173d30337",
+                "sha256:210c02f923df33a8d0e461c86fdcbbb17228ff4f6d92609fc06370a98d283c2d",
+                "sha256:2d0807ba935f540d20b49d5bf1c0237b90ce81e133402feda906e540003f2f7a",
+                "sha256:35d7a013874a7c927ce997350d314144ffc5465faf787bb4e46e6c4f381ef562",
+                "sha256:3636f9d0dcb01aed4180ef2e57a4e34bb4cac3ecd203c2a23db8526d86ab2fb4",
+                "sha256:42f4be770af2455a75e4640f033a82c62f3fb0d7a074123266e143269d7010ef",
+                "sha256:48440b25ba6cda72d4c638f3a9efa827b5b87b489c96ab5f4ff597d976413156",
+                "sha256:4dac8dfd1acf6a3ac657475dfdc66c621f291b1b7422a939cc33c13ac5356473",
+                "sha256:4e8474771c69c2991d5eab65764289a7dd450bbea050bc0ebb42b678d8222b42",
+                "sha256:551f10ddfeff56a1325e5a34eff304c5892aa981fd810babb98bfee77ee2fb17",
+                "sha256:5b104982f1809c1577912519eb249f17d9d7e66304ad026666cb60a5ef73309c",
+                "sha256:5c62aef73dfc87bfcca32cee149a1a7a602bc74bac72223236b0023543511c88",
+                "sha256:633151f8d1ad9467b9f7e90854a7f46ed8f2919e8bc7d98d737833e8938fc081",
+                "sha256:772207b9e2d5bf3f9d283b88915723e4e92d9a62c83f44ec92b9bd0cd685541b",
+                "sha256:7d5e02f647cd727afc2659ec14d4d1cc0508c47e6cfb07aea33d7aa9ca94d288",
+                "sha256:a9798a4111abb0f94584000ba2a2c74841f2cfe5f9254709756367aabbae0541",
+                "sha256:b38ea741ab9e35bfa7015c93c93bbd6a1623428f97a67083fc8ebd366238b91f",
+                "sha256:b6a5478c904236543c0347db8a05fac6fc0bd574c870e7970faa88e1d9890044",
+                "sha256:c6248bfc1de36a3844685a2e10ba17c18119ba6252547f921062a323fb31bff1",
+                "sha256:c705ab445936457359b1424ef25ccc0098b0491b26064677c39f1d14a539f056",
+                "sha256:d95a363d663ceee647291131dbd213af258df24f41350246842481ec3709bd33",
+                "sha256:e27265eb80cdc5dab55a40ef6f890e04ecc618649ad3da5265f128b141f93f78",
+                "sha256:ebc276c9cb5d917bd2ae959f84ffc279acafa9c9b50b0fa436ebb70bbe2166ea",
+                "sha256:f4d229866d030863d0fe3bf297d6d11e6133ca15bbb41ed2534a8b9a3d6bd061",
+                "sha256:f95675bd88b51474d4fe5165f3266f419ce754ffadfb97f10323931fa9ac95e5",
+                "sha256:f95bc54fb6d61b9f9ff09c4ae8ff6a3f5edc937cda3ca36fc937302a7c152bf1",
+                "sha256:fd0f6be53de40683584e5331c341e65a679dbe5ec489a0697cec7c2ef1a48cda"
+            ],
+            "version": "==5.0a4"
         },
         "crayons": {
             "hashes": [
@@ -211,10 +315,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "version": "==2.7"
+            "version": "==2.8"
         },
         "imagesize": {
             "hashes": [
@@ -238,6 +342,15 @@
             ],
             "index": "pypi",
             "version": "==1.2.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+            ],
+            "index": "pypi",
+            "version": "==4.3.4"
         },
         "jinja2": {
             "hashes": [
@@ -412,6 +525,12 @@
             ],
             "version": "==2.4.0"
         },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
@@ -441,12 +560,28 @@
             "index": "pypi",
             "version": "==4.0.1"
         },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
+                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        },
         "pytest-forked": {
             "hashes": [
                 "sha256:e4500cd0509ec4a26535f7d4112a8cc0f17d3a41c29ffd4eab479d2a55b30805",
                 "sha256:f275cb48a73fc61a6710726348e1da6d68a978f0ec0c54ece5a5fae5977e5a08"
             ],
             "version": "==0.2"
+        },
+        "pytest-timeout": {
+            "hashes": [
+                "sha256:4a30ba76837a32c7b7cd5c84ee9933fde4b9022b0cd20ea7d4a577c2a1649fb1",
+                "sha256:d49f618c6448c14168773b6cdda022764c63ea80d42274e3156787e8088d04c6"
+            ],
+            "index": "pypi",
+            "version": "==1.3.3"
         },
         "pytest-xdist": {
             "hashes": [
@@ -483,10 +618,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
-                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
             ],
-            "version": "==2.20.1"
+            "version": "==2.21.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -521,10 +656,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "snowballstemmer": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ console_scripts =
 
 [tool:pytest]
 strict = true
-addopts = -ra -n auto --timeout 300
+addopts = -ra --timeout 300
 testpaths = tests/
 norecursedirs = .* build dist news tasks docs
 filterwarnings =

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,10 +61,11 @@ exclude =
 [options.extras_require]
 tests =
     pytest
-    twine
-    readme_renderer[md]
     pytest-cov
     pytest-timeout
+    pytest-xdist
+    twine
+    readme_renderer[md]
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ console_scripts =
 
 [tool:pytest]
 strict = true
-addopts = -ra
+addopts = -ra -n auto --timeout 300
 testpaths = tests/
 norecursedirs = .* build dist news tasks docs
 filterwarnings =

--- a/src/pythonfinder/__init__.py
+++ b/src/pythonfinder/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 __version__ = '1.1.11.dev0'
 

--- a/src/pythonfinder/__main__.py
+++ b/src/pythonfinder/__main__.py
@@ -6,10 +6,12 @@ from __future__ import absolute_import
 import os
 import sys
 
+from pythonfinder.cli import cli
+
+
 PYTHONFINDER_MAIN = os.path.dirname(os.path.abspath(__file__))
 PYTHONFINDER_PACKAGE = os.path.dirname(PYTHONFINDER_MAIN)
 
-from pythonfinder.cli import cli
 
 if __name__ == "__main__":
     sys.exit(cli())

--- a/src/pythonfinder/environment.py
+++ b/src/pythonfinder/environment.py
@@ -1,5 +1,6 @@
 # -*- coding=utf-8 -*-
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
+
 import os
 import platform
 import sys

--- a/src/pythonfinder/exceptions.py
+++ b/src/pythonfinder/exceptions.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 
 class InvalidPythonVersion(Exception):

--- a/src/pythonfinder/models/mixins.py
+++ b/src/pythonfinder/models/mixins.py
@@ -16,7 +16,7 @@ from ..environment import MYPY_RUNNING
 from ..exceptions import InvalidPythonVersion
 from ..utils import (
     KNOWN_EXTS, Sequence, expand_paths, looks_like_python,
-    path_is_known_executable, unnest
+    path_is_known_executable
 )
 
 

--- a/src/pythonfinder/models/mixins.py
+++ b/src/pythonfinder/models/mixins.py
@@ -3,17 +3,22 @@ from __future__ import absolute_import, unicode_literals
 
 import abc
 import operator
+
 from collections import defaultdict
 
 import attr
 import six
-from cached_property import cached_property
 
+from cached_property import cached_property
 from vistir.compat import fs_str
+
 from ..environment import MYPY_RUNNING
 from ..exceptions import InvalidPythonVersion
-from ..utils import (KNOWN_EXTS, looks_like_python, expand_paths,
-                     path_is_known_executable, unnest, Sequence)
+from ..utils import (
+    KNOWN_EXTS, Sequence, expand_paths, looks_like_python,
+    path_is_known_executable, unnest
+)
+
 
 if MYPY_RUNNING:
     from .path import PathEntry

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -13,29 +13,20 @@ import attr
 import six
 
 from cached_property import cached_property
-
 from vistir.compat import Path, fs_str
 
-from .mixins import BasePath, BaseFinder
 from ..environment import (
-    PYENV_INSTALLED, PYENV_ROOT, ASDF_INSTALLED, ASDF_DATA_DIR, MYPY_RUNNING, SHIM_PATHS
+    ASDF_DATA_DIR, ASDF_INSTALLED, MYPY_RUNNING, PYENV_INSTALLED, PYENV_ROOT,
+    SHIM_PATHS
 )
 from ..exceptions import InvalidPythonVersion
 from ..utils import (
-    ensure_path,
-    filter_pythons,
-    looks_like_python,
-    optional_instance_of,
-    path_is_known_executable,
-    unnest,
-    normalize_path,
-    parse_pyenv_version_order,
-    parse_asdf_version_order,
-    Iterable,
-    Sequence,
-    expand_paths,
-    is_in_path
+    Iterable, Sequence, ensure_path, expand_paths, filter_pythons, is_in_path,
+    looks_like_python, normalize_path, optional_instance_of,
+    parse_asdf_version_order, parse_pyenv_version_order,
+    path_is_known_executable, unnest
 )
+from .mixins import BaseFinder, BasePath
 from .python import PythonVersion
 
 

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -12,16 +12,16 @@ from collections import defaultdict
 import attr
 import six
 
-from packaging.version import Version, parse as parse_version
-
+from packaging.version import Version
+from packaging.version import parse as parse_version
 from vistir.compat import Path, lru_cache
 
 from ..environment import ASDF_DATA_DIR, MYPY_RUNNING, PYENV_ROOT, SYSTEM_ARCH
 from ..exceptions import InvalidPythonVersion
 from ..utils import (
-    _filter_none, ensure_path, get_python_version, is_in_path,
-    optional_instance_of, parse_asdf_version_order, parse_pyenv_version_order,
-    parse_python_version, unnest, RE_MATCHER, looks_like_python
+    RE_MATCHER, _filter_none, ensure_path, get_python_version, is_in_path,
+    looks_like_python, optional_instance_of, parse_asdf_version_order,
+    parse_pyenv_version_order, parse_python_version, unnest
 )
 from .mixins import BaseFinder, BasePath
 

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -13,7 +13,6 @@ import attr
 import six
 
 from packaging.version import Version
-from packaging.version import parse as parse_version
 from vistir.compat import Path, lru_cache
 
 from ..environment import ASDF_DATA_DIR, MYPY_RUNNING, PYENV_ROOT, SYSTEM_ARCH

--- a/src/pythonfinder/models/windows.py
+++ b/src/pythonfinder/models/windows.py
@@ -7,12 +7,13 @@ from collections import defaultdict
 
 import attr
 
+from ..environment import MYPY_RUNNING
 from ..exceptions import InvalidPythonVersion
 from ..utils import ensure_path
 from .mixins import BaseFinder
 from .path import PathEntry
 from .python import PythonVersion, VersionMap
-from ..environment import MYPY_RUNNING
+
 
 if MYPY_RUNNING:
     from typing import DefaultDict, Tuple, List, Optional, Union, TypeVar, Type, Any

--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -7,7 +7,6 @@ import os
 import six
 
 from click import secho
-
 from vistir.compat import lru_cache
 
 from . import environment

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -1,22 +1,22 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function
 
+import io
 import itertools
 import os
+import re
 
 from fnmatch import fnmatch
 
 import attr
-import io
-import re
 import six
-
 import vistir
 
 from packaging.version import LegacyVersion, Version
 
-from .environment import PYENV_ROOT, ASDF_DATA_DIR, MYPY_RUNNING
+from .environment import ASDF_DATA_DIR, MYPY_RUNNING, PYENV_ROOT
 from .exceptions import InvalidPythonVersion
+
 
 six.add_move(six.MovedAttribute("Iterable", "collections", "collections.abc"))  # type: ignore  # noqa
 six.add_move(six.MovedAttribute("Sequence", "collections", "collections.abc"))  # type: ignore  # noqa

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -14,7 +14,7 @@ import vistir
 
 from packaging.version import LegacyVersion, Version
 
-from .environment import ASDF_DATA_DIR, MYPY_RUNNING, PYENV_ROOT
+from .environment import MYPY_RUNNING, PYENV_ROOT
 from .exceptions import InvalidPythonVersion
 
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 import re
 import sys
+
 from pathlib import Path
 
 import invoke
+
 from parver import Version
 
 from .vendoring import drop_dir, remove_all
+
 
 TASK_NAME = "RELEASE"
 

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -1,12 +1,14 @@
 # -*- coding=utf-8 -*-
-""""Vendoring script, python 3.5 needed"""
 # Taken from pip also
-from pathlib import Path
+""""Vendoring script, python 3.5 needed"""
 import os
 import re
 import shutil
 
+from pathlib import Path
+
 import invoke
+
 
 TASK_NAME = 'update'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,17 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function
 
-import click
-import click.testing
-
 import itertools
-import random
-
 import os
+import random
 import sys
 
+import click
+import click.testing
 import pytest
+import vistir
 
 import pythonfinder
-import vistir
 
 
 # def pytest_generate_tests(metafunc):
@@ -30,8 +28,6 @@ import vistir
 # def python(request):
 #     return request.params
 
-import click
-import click.testing
 
 
 STACKLESS = [

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,11 +1,13 @@
 # -*- coding=utf-8 -*-
 
-import pythonfinder
-import pytest
 import os
+
+import pytest
 import six
 
 from packaging.version import Version
+
+import pythonfinder
 
 
 def test_python_versions(monkeypatch, special_character_python):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,16 @@
 # -*- coding=utf-8 -*-
 
-import pytest
 import os
 
-os.environ["ANSI_COLORS_DISABLED"] = "1"
+import pytest
 import vistir
+
 import pythonfinder.utils
+
 from pythonfinder import Finder
+
+
+os.environ["ANSI_COLORS_DISABLED"] = "1"
 
 
 def _get_python_versions():

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,8 @@ passenv = CI GIT_SSL_CAINFO
 setenv =
     LC_ALL = en_US.UTF-8
 deps =
-	coverage
 	-e .[tests]
-commands = coverage run -m pytest --timeout 300 []
+commands = coverage run -m pytest
 install_command = python -m pip install {opts} {packages} --upgrade-strategy=eager
 usedevelop = True
 
@@ -30,10 +29,8 @@ commands =
 
 [testenv:packaging]
 deps =
-    twine
     setuptools
     -e .[tests]
-    readme_renderer[md]
 commands =
     python setup.py sdist
     twine check dist/*


### PR DESCRIPTION
- The dependencies are all moved to Pipfile, and then we don't need to install them manually in travis/tox
- The imports are resorted by ```isort```