### PR TITLE
Sort pythons by version and then by path

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ console_scripts =
 
 [tool:pytest]
 strict = true
-addopts = -ra --timeout 300
+addopts = -ra -n auto --timeout 300
 testpaths = tests/
 norecursedirs = .* build dist news tasks docs
 filterwarnings =

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ console_scripts =
 
 [tool:pytest]
 strict = true
-addopts = -ra -n auto --timeout 300
+addopts = -ra --timeout 300
 testpaths = tests/
 norecursedirs = .* build dist news tasks docs
 filterwarnings =

--- a/src/pythonfinder/models/mixins.py
+++ b/src/pythonfinder/models/mixins.py
@@ -295,7 +295,7 @@ class BasePath(object):
                 version_matcher(entry.py_version))
         ]
         results = sorted(matching_pythons,
-            key=operator.itemgetter(1),
+            key=operator.itemgetter(1, 0),
             reverse=True,
         )
         return next(iter(r[0] for r in results if r is not None), None)


### PR DESCRIPTION
This PR partly solves the non-deterministic result issue of pythonfinder.

For a python location, it may have following different path which has same ```version_sort``` as ```3.6.6.2```. This PR sorts them first by version and then by path and now always ```.../.pyenv/versions/3.6.6/bin/python3.6m``` is returned first.

- ```.../.pyenv/versions/3.6.6/bin/python3```
- ```.../.pyenv/versions/3.6.6/bin/python3.6```
- ```.../.pyenv/versions/3.6.6/bin/python3.6m```

But the xdist still doesn't work.