### PR TITLE
Parse numeric version inputs using RE parser

### DIFF
--- a/news/59.bugfix.rst
+++ b/news/59.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which prevented parsing of numeric versions as inputs to pythonfinder.

--- a/news/61.bugfix.rst
+++ b/news/61.bugfix.rst
@@ -1,0 +1,1 @@
+Windows path discovery now works correctly and does not attempt to assign cached properties.

--- a/src/pythonfinder/models/mixins.py
+++ b/src/pythonfinder/models/mixins.py
@@ -85,7 +85,7 @@ class BasePath(object):
             if key in self.__dict__:
                 del self.__dict__[key]
         self._children = {}
-        for key in self._pythons.keys():
+        for key in list(self._pythons.keys()):
             del self._pythons[key]
 
     @property

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -552,8 +552,8 @@ class PathEntry(BasePath):
     is_root = attr.ib(default=True, type=bool)
 
     def __del__(self):
-        if "children" in self.__dict__:
-            del self.__dict__["children"]
+        if "_children" in self.__dict__:
+            del self.__dict__["_children"]
         BasePath.__del__(self)
 
     def _filter_children(self):

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -336,6 +336,8 @@ class PythonVersion(object):
             elif self.comes_from:
                 executable = self.comes_from.path.as_posix()
             if executable is not None:
+                if not isinstance(executable, six.string_types):
+                    executable = executable.as_posix()
                 instance_dict = self.parse_executable(executable)
                 self.update_metadata(instance_dict)
                 result = instance_dict.get(key)
@@ -551,6 +553,8 @@ class PythonVersion(object):
         result_version = None  # type: Optional[str]
         if path is None:
             raise TypeError("Must pass a valid path to parse.")
+        if not isinstance(path, six.string_types):
+            path = path.as_posix()
         try:
             result_version = get_python_version(path)
         except Exception:

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -591,7 +591,6 @@ class PythonVersion(object):
         )
         py_version = cls.create(**creation_dict)
         comes_from = PathEntry.create(exe_path, only_python=True, name=name)
-        comes_from.py_version = copy.deepcopy(py_version)
         py_version.comes_from = comes_from
         py_version.name = comes_from.name
         return py_version

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -316,7 +316,7 @@ class PythonFinder(BaseFinder, BasePath):
 class PythonVersion(object):
     major = attr.ib(default=0, type=int)
     minor = attr.ib(default=None)  # type: Optional[int]
-    patch = attr.ib(default=0)  # type: Optional[int]
+    patch = attr.ib(default=None)  # type: Optional[int]
     is_prerelease = attr.ib(default=False, type=bool)
     is_postrelease = attr.ib(default=False, type=bool)
     is_devrelease = attr.ib(default=False, type=bool)
@@ -339,7 +339,13 @@ class PythonVersion(object):
                 if not isinstance(executable, six.string_types):
                     executable = executable.as_posix()
                 instance_dict = self.parse_executable(executable)
-                self.update_metadata(instance_dict)
+                for k in instance_dict.keys():
+                    try:
+                        super(PythonVersion, self).__getattribute__(k)
+                    except AttributeError:
+                        continue
+                    else:
+                        setattr(self, k, instance_dict[k])
                 result = instance_dict.get(key)
         return result
 

--- a/src/pythonfinder/models/windows.py
+++ b/src/pythonfinder/models/windows.py
@@ -65,7 +65,7 @@ class WindowsFinder(BaseFinder):
             pre=pre,
             dev=dev,
             arch=arch,
-            name=None,
+            name=name,
             )), None
         )
 

--- a/src/pythonfinder/models/windows.py
+++ b/src/pythonfinder/models/windows.py
@@ -39,13 +39,13 @@ class WindowsFinder(BaseFinder):
     ):
         # type (...) -> List[PathEntry]
         version_matcher = operator.methodcaller(
-            "matches", major, minor, patch, pre, dev, arch, python_version=name
+            "matches", major, minor, patch, pre, dev, arch, python_name=name
         )
-        py_filter = filter(
-            None, filter(lambda c: version_matcher(c), self.version_list)
-        )
+        pythons = [
+            py for py in self.version_list if version_matcher(py)
+        ]
         version_sort = operator.attrgetter("version_sort")
-        return [c.comes_from for c in sorted(py_filter, key=version_sort, reverse=True)]
+        return [c.comes_from for c in sorted(pythons, key=version_sort, reverse=True)]
 
     def find_python_version(
         self,


### PR DESCRIPTION
- Uses existing parser built for handling complex versions
- Is sufficiently robust, should handle most circumstances
- Fixes #59
- Closes and supersedes #57

Signed-off-by: Dan Ryan <dan@danryan.co>