### PR TITLE
setup.cfg: Remove indirect runtime dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,12 +41,9 @@ package_data =
     README*
 install_requires =
     attrs
-    backports.functools_lru_cache;python_version<="3.4"
     cached-property
     click
     crayons
-    packaging
-    pathlib2;python_version<"3.5"
     six
     vistir[spinner]>=0.3
 
@@ -59,6 +56,7 @@ exclude =
 
 [options.extras_require]
 tests =
+    packaging
     pytest
     pytest-cov
     pytest-timeout


### PR DESCRIPTION
The backports are obtained via vistir and thus better managed there,
also packaging is only used directly in the test suite.