### PR TITLE
Remove unworkable example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,6 @@ Using PythonFinder is easy.  Simply import it and ask for a python:
 
 .. code-block:: pycon
 
-    >>> from pythonfinder.pythonfinder import PythonFinder
-    >>> PythonFinder.from_line('python3')
-    '/home/techalchemy/.pyenv/versions/3.6.5/python3'
-
     >>> from pythonfinder import Finder
     >>> f = Finder()
     >>> f.find_python_version(3, minor=6)


### PR DESCRIPTION
`from pythonfinder.pythonfinder import PythonFinder` doesn't works. it is already migrated to `models/python`.