### PR TITLE
Filter out .exe interpreters on WSL

### DIFF
--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -58,7 +58,10 @@ PYTHON_IMPLEMENTATIONS = (
     "pyston",
     "micropython",
 )
-KNOWN_EXTS = {"exe", "py", "fish", "sh", ""}
+if os.name == "nt":
+    KNOWN_EXTS = {"exe", "py", "bat", ""}
+else:
+    KNOWN_EXTS = {"sh", "bash", "csh", "zsh", "fish", "py", ""}
 KNOWN_EXTS = KNOWN_EXTS | set(
     filter(None, os.environ.get("PATHEXT", "").split(os.pathsep))
 )


### PR DESCRIPTION
On WSL pythonfinder will find interpreters on Windows and may pick from them, while not working at all.

Related issue: https://github.com/pypa/pipenv/issues/3807