### PR TITLE
Strip out unnecessary dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -79,24 +79,8 @@
                 "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848",
                 "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"
             ],
-            "markers": "python_version < '3.2'",
+            "markers": "python_version == '2.7'",
             "version": "==1.6.1"
-        },
-        "backports.shutil-get-terminal-size": {
-            "hashes": [
-                "sha256:0975ba55054c15e346944b38956a4c9cbee9009391e41b86c68990effb8c1f64",
-                "sha256:713e7a8228ae80341c70586d1cc0a8caa5207346927e23d09dcbcaf18eadec80"
-            ],
-            "markers": "python_version == '2.7'",
-            "version": "==1.0.0"
-        },
-        "backports.weakref": {
-            "hashes": [
-                "sha256:81bc9b51c0abc58edc76aefbbc68c62a787918ffe943a37947e162c3f8e19e82",
-                "sha256:bc4170a29915f8b22c9e7c4939701859650f2eb84184aee80da329ac0b9825c2"
-            ],
-            "markers": "python_version == '2.7'",
-            "version": "==1.0.post1"
         },
         "black": {
             "hashes": [
@@ -222,14 +206,6 @@
             ],
             "version": "==0.4.2"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
-                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.4.3"
-        },
         "configparser": {
             "hashes": [
                 "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c",
@@ -283,13 +259,6 @@
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
             "version": "==4.5.4"
-        },
-        "crayons": {
-            "hashes": [
-                "sha256:50e5fa729d313e2c607ae8bf7b53bb487652e10bd8e7a1e08c4bc8bf62755ffc",
-                "sha256:8c9e4a3a607bc10e9a9140d496ecd16c6805088dd16c852c378f1f1d5db7aeb6"
-            ],
-            "version": "==0.3.0"
         },
         "cryptography": {
             "hashes": [
@@ -674,7 +643,7 @@
                 "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db",
                 "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
             ],
-            "markers": "python_version < '3'",
+            "markers": "python_version < '3.5'",
             "version": "==2.3.5"
         },
         "pathspec": {
@@ -847,29 +816,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:032fdcc03406e1a6485ec09b826eac78732943840c4b29e503b789716f051d8d",
-                "sha256:0e6cf1e747f383f52a0964452658c04300a9a01e8a89c55ea22813931b580aa8",
-                "sha256:106e25a841921d8259dcef2a42786caae35bc750fb996f830065b3dfaa67b77e",
-                "sha256:1768cf42a78a11dae63152685e7a1d90af7a8d71d2d4f6d2387edea53a9e0588",
-                "sha256:27d1bd20d334f50b7ef078eba0f0756a640fd25f5f1708d3b5bed18a5d6bced9",
-                "sha256:29b20f66f2e044aafba86ecf10a84e611b4667643c42baa004247f5dfef4f90b",
-                "sha256:4850c78b53acf664a6578bba0e9ebeaf2807bb476c14ec7e0f936f2015133cae",
-                "sha256:57eacd38a5ec40ed7b19a968a9d01c0d977bda55664210be713e750dd7b33540",
-                "sha256:724eb24b92fc5fdc1501a1b4df44a68b9c1dda171c8ef8736799e903fb100f63",
-                "sha256:77ae8d926f38700432807ba293d768ba9e7652df0cbe76df2843b12f80f68885",
-                "sha256:78b3712ec529b2a71731fbb10b907b54d9c53a17ca589b42a578bc1e9a2c82ea",
-                "sha256:7bbbdbada3078dc360d4692a9b28479f569db7fc7f304b668787afc9feb38ec8",
-                "sha256:8d9ef7f6c403e35e73b7fc3cde9f6decdc43b1cb2ff8d058c53b9084bfcb553e",
-                "sha256:a83049eb717ae828ced9cf607845929efcb086a001fc8af93ff15c50012a5716",
-                "sha256:adc35d38952e688535980ae2109cad3a109520033642e759f987cf47fe278aa1",
-                "sha256:c29a77ad4463f71a506515d9ec3a899ed026b4b015bf43245c919ff36275444b",
-                "sha256:cfd31b3300fefa5eecb2fe596c6dee1b91b3a05ece9d5cfd2631afebf6c6fadd",
-                "sha256:d3ee0b035816e0520fac928de31b6572106f0d75597f6fa3206969a02baba06f",
-                "sha256:d508875793efdf6bab3d47850df8f40d4040ae9928d9d80864c1768d6aeaf8e3",
-                "sha256:ef0b828a7e22e58e06a1cceddba7b4665c6af8afeb22a0d8083001330572c147",
-                "sha256:faad39fdbe2c2ccda9846cd21581063086330efafa47d87afea4073a08128656"
+                "sha256:08047f4b31254489316b489c24983d72c0b9d520da084b8c624f45891a9c6da2",
+                "sha256:08d042155592c24cbdb81158a99aeeded4493381a1aba5eba9def6d29961042c",
+                "sha256:13901ac914de7a7e58a92f99c71415e268e88ac4be8b389d8360c38e64b2f1c5",
+                "sha256:15b6f7e10f764c5162242a7db89da51218a38299415ba5e70f235a6a83c53b94",
+                "sha256:46d01bb4139e7051470037f8b9a5b90c48cb77a3d307c2621bf3791bfae4d9d8",
+                "sha256:52814a8423d52a7e0f070dbb79f7bdfce5221992b881f83bad69f8daf4b831c3",
+                "sha256:6d999447f77b1b638ea620bde466b958144af90ac2e9b1f23b98a79ced14ce3f",
+                "sha256:7391eeee49bb3ce895ca43479eaca810f0c2608556711fa02a82075768f81a37",
+                "sha256:79530d60a8644f72f78834c01a2d70a60be110e2f4a0a612b78da23ef60c2730",
+                "sha256:841056961d441f05b949d9003e7f2b5d51a11dd52d8bd7c0a5325943b6a0ea6b",
+                "sha256:895f95344182b4ecb84044910e62ad33ca63a7e7b447c7ba858d24e9f1aad939",
+                "sha256:93e797cf16e07b315413d1157b5ce7a7c2b28b2b95768e25c0ccd290443661ad",
+                "sha256:a4677dc8245f1127b70fa79fb7f15a61eae0fee36ae15cbbe017207485fe9a5c",
+                "sha256:b2faf1dce478c0ca1c92575bdc48b7afdce3a887a02afb6342fae476af41bbe2",
+                "sha256:bcd9bcba67ae8d1e1b21426ea7995f7ca08260bea601ba15e13e5ca8588208ef",
+                "sha256:d47a89e6029852c88fff859dbc9a11dcec820413b4c2510e80ced1c99c3e79ea",
+                "sha256:dd69d165bee099b02d122d1e0dd55a85ebf9a65493dcd17124b628db9edfc833",
+                "sha256:e77f64a3ae8b9a555e170a3908748b4e2ccd0c58f8385f328baf8fc70f9ea497",
+                "sha256:ec75e8baa576aed6065b615a8f8e91a05e42b492b24ffd16cbb075ad62fb9185",
+                "sha256:ed75b64c6694bbe840b3340191b2039f633fd1ec6fc567454e47d7326eda557f",
+                "sha256:ef85a6a15342559bed737dc16dfb1545dc043ca5bf5bce6bff4830f0e7a74395"
             ],
-            "version": "==2019.12.20"
+            "version": "==2020.1.7"
         },
         "requests": {
             "hashes": [
@@ -1074,17 +1043,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==16.7.9"
         },
-        "vistir": {
-            "extras": [
-                "spinner"
-            ],
-            "hashes": [
-                "sha256:2166e3148a67c438c9e3edbba0cde153d42dec6e3bf5d8f4624feb27686c0990",
-                "sha256:3a0529b4b6c2e842fd19b5ceaa95b6c9201321314825c110406d4af3331a0709"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.4.3"
-        },
         "watchdog": {
             "hashes": [
                 "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
@@ -1112,13 +1070,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.33.6"
-        },
-        "yaspin": {
-            "hashes": [
-                "sha256:0ee4668936d0053de752c9a4963929faa3a832bd0ba823877d27855592dc80aa",
-                "sha256:5a938bdc7bab353fd8942d0619d56c6b5159a80997dc1c387a479b39e6dc9391"
-            ],
-            "version": "==0.15.0"
         },
         "zipp": {
             "hashes": [

--- a/news/78.feature.rst
+++ b/news/78.feature.rst
@@ -1,0 +1,1 @@
+Reduced dependencies by removing ``vistir``,, ``crayons`` and intermediate calls.

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,10 @@ install_requires =
     attrs
     cached-property
     click
-    crayons
     six
     packaging
-    vistir[spinner]>=0.4
+    backports.functools_lru_cache;python_version=="2.7"
+    pathlib2;python_version<"3.5"
 
 [options.packages.find]
 where = src

--- a/src/pythonfinder/cli.py
+++ b/src/pythonfinder/cli.py
@@ -1,10 +1,7 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-import sys
-
 import click
-import crayons
 
 from . import __version__
 from .pythonfinder import Finder
@@ -32,10 +29,11 @@ def cli(
     if version:
         click.echo(
             "{0} version {1}".format(
-                crayons.white("PythonFinder", bold=True), crayons.yellow(__version__)
+                click.style("PythonFinder", fg="white", bold=True),
+                click.style(str(__version__), fg="yellow")
             )
         )
-        sys.exit(0)
+        ctx.exit()
     finder = Finder(ignore_unsupported=ignore_unsupported)
     if findall:
         versions = [v for v in finder.find_all_python_versions()]
@@ -54,7 +52,7 @@ def cli(
                     ),
                     fg="yellow",
                 )
-            sys.exit(0)
+            ctx.exit()
         else:
             click.secho(
                 "ERROR: No valid python versions found! Check your path and try again.",
@@ -78,22 +76,22 @@ def cli(
                 ),
                 fg="yellow",
             )
-            sys.exit(0)
+            ctx.exit()
         else:
             click.secho("Failed to find matching executable...", fg="yellow")
-            sys.exit(1)
+            ctx.exit(1)
     elif which:
         found = finder.system_path.which(which.strip())
         if found:
             click.secho("Found Executable: {0}".format(found), fg="white")
-            sys.exit(0)
+            ctx.exit()
         else:
             click.secho("Failed to find matching executable...", fg="yellow")
-            sys.exit(1)
+            ctx.exit(1)
     else:
         click.echo("Please provide a command", color="red")
-        sys.exit(1)
-    sys.exit()
+        ctx.exit(1)
+    ctx.exit()
 
 
 if __name__ == "__main__":

--- a/src/pythonfinder/compat.py
+++ b/src/pythonfinder/compat.py
@@ -1,0 +1,38 @@
+# -*- coding=utf-8 -*-
+import sys
+
+import six
+
+if sys.version_info[:2] <= (3, 4):
+    from pathlib2 import Path  # type: ignore  # noqa
+else:
+    from pathlib import Path
+
+if six.PY3:
+    from functools import lru_cache
+else:
+    from backports.functools_lru_cache import lru_cache  # type: ignore  # noqa
+
+
+def getpreferredencoding():
+    import locale
+    # Borrowed from Invoke
+    # (see https://github.com/pyinvoke/invoke/blob/93af29d/invoke/runners.py#L881)
+    _encoding = locale.getpreferredencoding(False)
+    if six.PY2 and not sys.platform == "win32":
+        _default_encoding = locale.getdefaultlocale()[1]
+        if _default_encoding is not None:
+            _encoding = _default_encoding
+    return _encoding
+
+
+DEFAULT_ENCODING = getpreferredencoding()
+
+
+def fs_str(string):
+    """Encodes a string into the proper filesystem encoding"""
+
+    if isinstance(string, str):
+        return string
+    assert not isinstance(string, bytes)
+    return string.encode(DEFAULT_ENCODING)

--- a/src/pythonfinder/compat.py
+++ b/src/pythonfinder/compat.py
@@ -10,8 +10,12 @@ else:
 
 if six.PY3:
     from functools import lru_cache
+    from builtins import TimeoutError
 else:
     from backports.functools_lru_cache import lru_cache  # type: ignore  # noqa
+
+    class TimeoutError(OSError):
+        pass
 
 
 def getpreferredencoding():

--- a/src/pythonfinder/models/mixins.py
+++ b/src/pythonfinder/models/mixins.py
@@ -7,8 +7,8 @@ from collections import defaultdict
 
 import attr
 import six
-from vistir.compat import fs_str
 
+from ..compat import fs_str
 from ..environment import MYPY_RUNNING
 from ..exceptions import InvalidPythonVersion
 from ..utils import (
@@ -35,7 +35,7 @@ if MYPY_RUNNING:
         TypeVar,
         Type,
     )
-    from vistir.compat import Path
+    from ..compat import Path
 
     BaseFinderType = TypeVar("BaseFinderType")
 

--- a/src/pythonfinder/models/mixins.py
+++ b/src/pythonfinder/models/mixins.py
@@ -35,7 +35,7 @@ if MYPY_RUNNING:
         TypeVar,
         Type,
     )
-    from ..compat import Path
+    from ..compat import Path  # noqa
 
     BaseFinderType = TypeVar("BaseFinderType")
 

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -10,8 +10,7 @@ from itertools import chain
 import attr
 import six
 from cached_property import cached_property
-from vistir.compat import Path, fs_str
-from vistir.misc import dedup
+from ..compat import Path, fs_str
 
 from ..environment import (
     ASDF_DATA_DIR,
@@ -26,6 +25,7 @@ from ..exceptions import InvalidPythonVersion
 from ..utils import (
     Iterable,
     Sequence,
+    dedup,
     ensure_path,
     expand_paths,
     filter_pythons,

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -10,8 +10,8 @@ from collections import defaultdict
 import attr
 import six
 from packaging.version import Version
-from vistir.compat import Path, lru_cache
 
+from ..compat import Path, lru_cache
 from ..environment import ASDF_DATA_DIR, MYPY_RUNNING, PYENV_ROOT, SYSTEM_ARCH
 from ..exceptions import InvalidPythonVersion
 from ..utils import (

--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -7,9 +7,9 @@ import os
 
 import six
 from click import secho
-from vistir.compat import lru_cache
 
 from . import environment
+from .compat import lru_cache
 from .exceptions import InvalidPythonVersion
 from .utils import Iterable, filter_pythons, version_re
 
@@ -51,7 +51,8 @@ class Finder(object):
         :param system: bool, optional
         :param global_search: Whether to search the global path from os.environ, defaults to True
         :param global_search: bool, optional
-        :param ignore_unsupported: Whether to ignore unsupported python versions, if False, an error is raised, defaults to True
+        :param ignore_unsupported: Whether to ignore unsupported python versions, if False, an
+            error is raised, defaults to True
         :param ignore_unsupported: bool, optional
         :param bool sort_by_path: Whether to always sort by path
         :returns: a :class:`~pythonfinder.pythonfinder.Finder` object.
@@ -133,8 +134,16 @@ class Finder(object):
         return self.system_path.which(exe)
 
     @classmethod
-    def parse_major(cls, major, minor=None, patch=None, pre=None, dev=None, arch=None):
-        # type: (Optional[str], Optional[int], Optional[int], Optional[bool], Optional[bool], Optional[str]) -> Dict[str, Union[int, str, bool, None]]
+    def parse_major(
+        cls,
+        major,  # type: Optional[str]
+        minor=None,  # type: Optional[int]
+        patch=None,  # type: Optional[int]
+        pre=None,  # type: Optional[bool]
+        dev=None,  # type: Optional[bool]
+        arch=None,  # type: Optional[str]
+    ):
+        # type: (...) -> Dict[str, Union[int, str, bool, None]]
         from .models import PythonVersion
 
         major_is_str = major and isinstance(major, six.string_types)
@@ -289,11 +298,18 @@ class Finder(object):
 
     @lru_cache(maxsize=1024)
     def find_all_python_versions(
-        self, major=None, minor=None, patch=None, pre=None, dev=None, arch=None, name=None
+        self,
+        major=None,  # type: Optional[Union[str, int]]
+        minor=None,  # type: Optional[int]
+        patch=None,  # type: Optional[int]
+        pre=None,  # type: Optional[bool]
+        dev=None,  # type: Optional[bool]
+        arch=None,  # type: Optional[str]
+        name=None,  # type: Optional[str]
     ):
-        # type: (Optional[Union[str, int]], Optional[int], Optional[int], Optional[bool], Optional[bool], Optional[str], Optional[str]) -> List[PathEntry]
+        # type: (...) -> List[PathEntry]
         version_sort = operator.attrgetter("as_python.version_sort")
-        python_version_dict = getattr(self.system_path, "python_version_dict")
+        python_version_dict = getattr(self.system_path, "python_version_dict", {})
         if python_version_dict:
             paths = (
                 path

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -5,14 +5,16 @@ import io
 import itertools
 import os
 import re
+import subprocess
+from collections import OrderedDict
 from fnmatch import fnmatch
 from threading import Timer
 
 import attr
 import six
-import vistir
 from packaging.version import LegacyVersion, Version
 
+from .compat import Path, lru_cache
 from .environment import MYPY_RUNNING, PYENV_ROOT, SUBPROCESS_TIMEOUT
 from .exceptions import InvalidPythonVersion
 
@@ -26,11 +28,6 @@ six.add_move(
 from six.moves import Iterable  # type: ignore  # noqa  # isort:skip
 from six.moves import Sequence  # type: ignore  # noqa  # isort:skip
 # fmt: on
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache  # type: ignore  # noqa
 
 if MYPY_RUNNING:
     from typing import Any, Union, List, Callable, Set, Tuple, Dict, Optional, Iterator
@@ -98,21 +95,26 @@ def get_python_version(path):
         "-c",
         "import sys; print('.'.join([str(i) for i in sys.version_info[:3]]))",
     ]
+    subprocess_kwargs = {
+        "env": os.environ.copy(),
+        "universal_newlines": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "shell": False,
+    }
+    c = subprocess.Popen(version_cmd, **subprocess_kwargs)
+    timer = Timer(SUBPROCESS_TIMEOUT, c.kill)
     try:
-        c = vistir.misc.run(
-            version_cmd,
-            block=True,
-            nospin=True,
-            return_object=True,
-            combine_stderr=False,
-            write_to_stdout=False,
-        )
-        timer = Timer(SUBPROCESS_TIMEOUT, c.kill)
+        out, err = c.communicate()
+    except (SystemExit, KeyboardInterrupt, TimeoutError):
+        c.terminate()
+        out, err = c.communicate()
+        raise
     except OSError:
         raise InvalidPythonVersion("%s is not a valid python path" % path)
-    if not c.out:
+    if not out:
         raise InvalidPythonVersion("%s is not a valid python path" % path)
-    return c.out.strip()
+    return out.strip()
 
 
 @lru_cache(maxsize=1024)
@@ -190,13 +192,13 @@ def path_is_executable(path):
 
 @lru_cache(maxsize=1024)
 def path_is_known_executable(path):
-    # type: (vistir.compat.Path) -> bool
+    # type: (Path) -> bool
     """
     Returns whether a given path is a known executable from known executable extensions
     or has the executable bit toggled.
 
     :param path: The path to the target executable.
-    :type path: :class:`~vistir.compat.Path`
+    :type path: :class:`~Path`
     :return: True if the path has chmod +x, or is a readable, known executable extension.
     :rtype: bool
     """
@@ -229,12 +231,12 @@ def looks_like_python(name):
 
 @lru_cache(maxsize=1024)
 def path_is_python(path):
-    # type: (vistir.compat.Path) -> bool
+    # type: (Path) -> bool
     """
     Determine whether the supplied path is executable and looks like a possible path to python.
 
     :param path: The path to an executable.
-    :type path: :class:`~vistir.compat.Path`
+    :type path: :class:`~Path`
     :return: Whether the provided path is an executable path to python.
     :rtype: bool
     """
@@ -278,7 +280,7 @@ def path_is_pythoncore(path):
 
 @lru_cache(maxsize=1024)
 def ensure_path(path):
-    # type: (Union[vistir.compat.Path, str]) -> vistir.compat.Path
+    # type: (Union[Path, str]) -> Path
     """
     Given a path (either a string or a Path object), expand variables and return a Path object.
 
@@ -288,9 +290,9 @@ def ensure_path(path):
     :rtype: :class:`~pathlib.Path`
     """
 
-    if isinstance(path, vistir.compat.Path):
+    if isinstance(path, Path):
         return path
-    path = vistir.compat.Path(os.path.expandvars(path))
+    path = Path(os.path.expandvars(path))
     return path.absolute()
 
 
@@ -313,10 +315,10 @@ def normalize_path(path):
 
 @lru_cache(maxsize=1024)
 def filter_pythons(path):
-    # type: (Union[str, vistir.compat.Path]) -> Iterable
+    # type: (Union[str, Path]) -> Iterable
     """Return all valid pythons in a given path"""
-    if not isinstance(path, vistir.compat.Path):
-        path = vistir.compat.Path(str(path))
+    if not isinstance(path, Path):
+        path = Path(str(path))
     if not path.is_dir():
         return path if path_is_python(path) else None
     return filter(path_is_python, path.iterdir())
@@ -377,7 +379,7 @@ def split_version_and_name(
     patch=None,  # type: Optional[Union[str, int]]
     name=None,  # type: Optional[str]
 ):
-    # type: (...) -> Tuple[Optional[Union[str, int]], Optional[Union[str, int]], Optional[Union[str, int]], Optional[str]]
+    # type: (...) -> Tuple[Optional[Union[str, int]], Optional[Union[str, int]], Optional[Union[str, int]], Optional[str]]  # noqa
     if isinstance(major, six.string_types) and not minor and not patch:
         # Only proceed if this is in the format "x.y.z" or similar
         if major.isdigit() or (major.count(".") > 0 and major[0].isdigit()):
@@ -437,3 +439,11 @@ def expand_paths(path, only_python=True):
     else:
         if path is not None and path.is_python and path.as_python is not None:
             yield path
+
+
+def dedup(iterable):
+    # type: (Iterable) -> Iterable
+    """Deduplicate an iterable object like iter(set(iterable)) but
+    order-reserved.
+    """
+    return iter(OrderedDict.fromkeys(iterable))

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -14,7 +14,7 @@ import attr
 import six
 from packaging.version import LegacyVersion, Version
 
-from .compat import Path, lru_cache
+from .compat import Path, lru_cache, TimeoutError  # noqa
 from .environment import MYPY_RUNNING, PYENV_ROOT, SUBPROCESS_TIMEOUT
 from .exceptions import InvalidPythonVersion
 
@@ -105,10 +105,10 @@ def get_python_version(path):
     c = subprocess.Popen(version_cmd, **subprocess_kwargs)
     timer = Timer(SUBPROCESS_TIMEOUT, c.kill)
     try:
-        out, err = c.communicate()
+        out, _ = c.communicate()
     except (SystemExit, KeyboardInterrupt, TimeoutError):
         c.terminate()
-        out, err = c.communicate()
+        out, _ = c.communicate()
         raise
     except OSError:
         raise InvalidPythonVersion("%s is not a valid python path" % path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,18 @@
 # -*- coding=utf-8 -*-
 
 import os
+import sys
 from collections import namedtuple
 
 import pytest
-import vistir
 
 import pythonfinder.utils
 from pythonfinder import Finder
+
+if sys.version_info[:2] < (3, 5):
+    from pathlib2 import Path
+else:
+    from pathlib import Path
 
 os.environ["ANSI_COLORS_DISABLED"] = "1"
 
@@ -72,4 +77,4 @@ def test_parse_python_version(python, expected):
 def test_is_python(python, expected):
     assert pythonfinder.utils.path_is_known_executable(python)
     assert pythonfinder.utils.looks_like_python(os.path.basename(python))
-    assert pythonfinder.utils.path_is_python(vistir.compat.Path(python))
+    assert pythonfinder.utils.path_is_python(Path(python))

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -65,7 +65,8 @@ def create_tracked_tempdir(*args, **kwargs):
     tempdir = tempfile.mkdtemp(*args, **kwargs)
     TRACKED_TEMPORARY_DIRECTORIES.append(tempdir)
     atexit.register(shutil.rmtree, tempdir)
-    warnings.simplefilter("ignore", ResourceWarning)
+    if six.PY3:
+        warnings.simplefilter("ignore", ResourceWarning)
     return tempdir
 
 


### PR DESCRIPTION
- Remove `vistir` and `crayons`
- Reimplement heavily relied-upon functionality
- Copy over `vistir` utilities used heavily in tests to avoid this as a
  test dependency as well
- Rewrite mocks that relied on vistir-specific invocations
- Regenerate lockfile
- Begins to address #78

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>