### PR TITLE
Unnest the mixed output

### DIFF
--- a/news/85.bugfix.rst
+++ b/news/85.bugfix.rst
@@ -1,0 +1,1 @@
+Unnest the mixed output from ``find_all_python_versions()``.

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -27,7 +27,6 @@ from ..utils import (
     Sequence,
     dedup,
     ensure_path,
-    expand_paths,
     filter_pythons,
     is_in_path,
     normalize_path,

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -287,7 +287,7 @@ class PythonFinder(BaseFinder, BasePath):
             ]
         else:
             pythons = [sub_finder(path) for path in self.paths]
-        pythons = expand_paths(pythons, True)
+        pythons = list(expand_paths(pythons, True))
         version_sort = operator.attrgetter("as_python.version_sort")
         paths = [
             p

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -285,7 +285,7 @@ class PythonFinder(BaseFinder, BasePath):
                 for _, base in self._iter_version_bases()
             ]
         else:
-            pythons = [sub_finder(path) for path in self.paths]
+            pythons = list(unnest(sub_finder(path) for path in self.paths))
         pythons = [p for p in pythons if p and p.is_python and p.as_python is not None]
         version_sort = operator.attrgetter("as_python.version_sort")
         paths = [

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -285,8 +285,14 @@ class PythonFinder(BaseFinder, BasePath):
                 for _, base in self._iter_version_bases()
             ]
         else:
-            pythons = list(unnest(sub_finder(path) for path in self.paths))
-        pythons = [p for p in pythons if p and p.is_python and p.as_python is not None]
+            pythons = [sub_finder(path) for path in self.paths]
+        try:
+            pythons = [
+                p for p in pythons if p and p.is_python and p.as_python is not None
+            ]
+        except AttributeError:
+            print(pythons)
+            raise
         version_sort = operator.attrgetter("as_python.version_sort")
         paths = [
             p

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -287,12 +287,10 @@ class PythonFinder(BaseFinder, BasePath):
             ]
         else:
             pythons = [sub_finder(path) for path in self.paths]
-        pythons = list(expand_paths(pythons, True))
+        pythons = expand_paths(pythons, True)
         version_sort = operator.attrgetter("as_python.version_sort")
         paths = [
-            p
-            for p in sorted(list(pythons), key=version_sort, reverse=True)
-            if p is not None
+            p for p in sorted(pythons, key=version_sort, reverse=True) if p is not None
         ]
         return paths
 

--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -18,6 +18,7 @@ from ..utils import (
     RE_MATCHER,
     _filter_none,
     ensure_path,
+    expand_paths,
     get_python_version,
     guess_company,
     is_in_path,
@@ -286,13 +287,7 @@ class PythonFinder(BaseFinder, BasePath):
             ]
         else:
             pythons = [sub_finder(path) for path in self.paths]
-        try:
-            pythons = [
-                p for p in pythons if p and p.is_python and p.as_python is not None
-            ]
-        except AttributeError:
-            print(pythons)
-            raise
+        pythons = expand_paths(pythons, True)
         version_sort = operator.attrgetter("as_python.version_sort")
         paths = [
             p

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -437,7 +437,9 @@ def expand_paths(path, only_python=True):
                 ):
                     yield sub_path
     else:
-        if path is not None and path.is_python and path.as_python is not None:
+        if path is not None and not (
+            only_python and path.is_python and path.as_python is not None
+        ):
             yield path
 
 

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -422,7 +422,7 @@ def expand_paths(path, only_python=True):
         isinstance(path, Sequence)
         and not getattr(path.__class__, "__name__", "") == "PathEntry"
     ):
-        for p in unnest(path):
+        for p in path:
             if p is None:
                 continue
             for expanded in itertools.chain.from_iterable(
@@ -437,8 +437,8 @@ def expand_paths(path, only_python=True):
                 ):
                     yield sub_path
     else:
-        if path is not None and not (
-            only_python and path.is_python and path.as_python is not None
+        if path is not None and (
+            not only_python or (path.is_python and path.as_python is not None)
         ):
             yield path
 


### PR DESCRIPTION
The `PythonFinder.find_all_python_versions()` mixed the output from subfinders of `find_all_python_versions()` and `find_python_version`. However, the former returns a list of path entries and the latter returns one.

The PR proposes a fix to unnest the results of both kinds of subfinders.

Fix #85 