### PR TITLE
Normalize case to improve windows path finding.

### DIFF
--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -429,7 +429,7 @@ class SystemPath(object):
         _path = self.paths.get(path)
         if not _path:
             _path = self.paths.get(path.as_posix())
-        if not _path and path.as_posix() in self.path_order:
+        if not _path and os.path.normcase(path.as_posix()) in self.path_order:
             _path = PathEntry.create(
                 path=path.absolute(), is_root=True, only_python=self.only_python
             )


### PR DESCRIPTION
This resolves [#4330 on pypa/pipenv](https://github.com/pypa/pipenv/issues/4330)


Since pipenv v2018.11.26 pathfinding on windows was broken in certain scenarios (See #4330)
This resolves the issue by properly normalizing the path. This should not affect other platforms since `os.path.normcase` has no effect on other platforms.