### PR TITLE
Filter out None results before sorting python version list

### DIFF
--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -324,6 +324,7 @@ class Finder(object):
         )
         if not isinstance(versions, Iterable):
             versions = [versions]
+        versions = filter(lambda version: version.as_python is not None, versions)
         # This list has already been mostly sorted on windows, we don't need to reverse it again
         path_list = sorted(versions, key=version_sort, reverse=True)
         path_map = {}  # type: Dict[str, PathEntry]


### PR DESCRIPTION
This solves the issue of trying to sort non-python results in the `find_all_python_versions` function.

This was attempted in https://github.com/sarugaku/pythonfinder/pull/87, but this is still an issue for me and [a lot of other users](https://github.com/pypa/pipenv/issues/4296#issuecomment-659837286).

For some reason, the `versions` list can contain non-existing entries. For instance on my machine it contains among others an entry of a version I uninstalled a long time ago:

```
PathEntry(path=WindowsPath('C:/Users/Chris/AppData/Local/Programs/Python/Python37/python.exe'), _children={}, only_python=True, name='3.7', _py_version=None, _pythons=defaultdict(None, {}), _is_dir=False, _is_executable=False, _is_python=False, is_root=False), 
```

When `as_python.version_sort` of such an entry is accessed in order to sort the list, it panics because `as_python` returns `None`.

It would probably be best to attack this issue at the source as well, but filtering out these kind of results at the location where they're accessed is a start.

