### PR TITLE
Fix Finder.which fail on non-existent path

### DIFF
--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -480,8 +480,16 @@ class SystemPath(object):
         """
 
         sub_which = operator.methodcaller("which", executable)
-        filtered = (sub_which(self.get_path(k)) for k in self.path_order)
-        return next(iter(f for f in filtered if f is not None), None)
+
+        def filtered():
+            for k in self.path_order:
+                try:
+                    p = self.get_path(k)
+                except ValueError:
+                    continue  # Path not found or generated..
+                yield sub_which(p)
+
+        return next(iter(f for f in filtered() if f is not None), None)
 
     def _filter_paths(self, finder):
         # type: (Callable) -> Iterator


### PR DESCRIPTION
## Problem
If system paths contains non-existent path, calling `Finder.which` would raise `ValueError` [from here](https://github.com/sarugaku/pythonfinder/blob/5d77853d2ae6f763b4d00ff675dc45fba262e283/src/pythonfinder/models/path.py#L439) and stop searching.

```
>>> import os
>>> from pythonfinder import Finder
>>> os.environ["PATH"] = "X:/foo;" + os.environ["PATH"]
>>> finder = Finder()
>>> finder.which("python")
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "C:\Python37_64\lib\site-packages\pythonfinder\pythonfinder.py", line 134, in which
    return self.system_path.which(exe)
  File "C:\Python37_64\lib\site-packages\pythonfinder\models\path.py", line 484, in which
    return next(iter(f for f in filtered if f is not None), None)
  File "C:\Python37_64\lib\site-packages\pythonfinder\models\path.py", line 484, in <genexpr>
    return next(iter(f for f in filtered if f is not None), None)
  File "C:\Python37_64\lib\site-packages\pythonfinder\models\path.py", line 483, in <genexpr>
    filtered = (sub_which(self.get_path(k)) for k in self.path_order)
  File "C:\Python37_64\lib\site-packages\pythonfinder\models\path.py", line 439, in get_path
    raise ValueError("Path not found or generated: {0!r}".format(path))
ValueError: Path not found or generated: WindowsPath('x:/foo')
```

## Propose
Forgive non-existent path and continue searching executable.