### PR TITLE
Windows pyenv-win/pipenv fixes

### DIFF
--- a/src/pythonfinder/models/python.py
+++ b/src/pythonfinder/models/python.py
@@ -5,6 +5,7 @@ import logging
 import operator
 import platform
 import sys
+import os
 from collections import defaultdict
 
 import attr
@@ -133,6 +134,8 @@ class PythonFinder(BaseFinder, BasePath):
         # type: (Union[Path, str]) -> Path
         if isinstance(base, six.string_types):
             base = Path(base)
+        if os.name == "nt":
+            return base
         return base / "bin"
 
     @classmethod

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -62,7 +62,7 @@ else:
 KNOWN_EXTS = KNOWN_EXTS | set(
     filter(None, os.environ.get("PATHEXT", "").split(os.pathsep))
 )
-PY_MATCH_STR = r"((?P<implementation>{0})(?:\d?(?:\.\d[cpm]{{0,3}}))?(?:-?[\d\.]+)*)".format(
+PY_MATCH_STR = r"((?P<implementation>{0})(?:\d?(?:\.\d[cpm]{{0,3}}))?(?:-?[\d\.]+)*[^w])".format(
     "|".join(PYTHON_IMPLEMENTATIONS)
 )
 EXE_MATCH_STR = r"{0}(?:\.(?P<ext>{1}))?".format(PY_MATCH_STR, "|".join(KNOWN_EXTS))


### PR DESCRIPTION
Currently on Windows with pipenv and pyenv-win, we append `/bin` when searching through the pyenv `/versions` subdirectory. This checks for windows and disables that, allowing pythonfinder to actually check `/versions/*/` for python executables.

Additionally, the `PY_MATCH_STR` regex was matching `pythonw.exe` as opposed to `python.exe` so that has been fixed by editing the regex string. 

With these two changes, `find_python_version()` appears to work which once vendored into pipenv will allow it to properly detect python versions before/after pyenv install.