### PR TITLE
Gracefully skip paths inaccessible due to filesystem permissions

### DIFF
--- a/news/111.bugfix.rst
+++ b/news/111.bugfix.rst
@@ -1,0 +1,1 @@
+Check the permission as well as the existence of path when finding Pythons.

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -64,8 +64,11 @@ if MYPY_RUNNING:
 def exists_and_is_accessible(path: Path) -> bool:
     try:
         return path.exists()
-    except PermissionError:
-        return False
+    except PermissionError as pe:
+        if pe.errno == 13: # Permission denied
+            return False
+        else:
+            raise
 
 @attr.s
 class SystemPath(object):

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 import operator
 import os
 import sys
+import errno
 from collections import defaultdict
 from itertools import chain
 
@@ -65,7 +66,7 @@ def exists_and_is_accessible(path: Path) -> bool:
     try:
         return path.exists()
     except PermissionError as pe:
-        if pe.errno == 13: # Permission denied
+        if pe.errno == errno.EACCES: # Permission denied
             return False
         else:
             raise

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -61,6 +61,11 @@ if MYPY_RUNNING:
     ChildType = Union[PythonFinder, "PathEntry"]
     PathType = Union[PythonFinder, "PathEntry"]
 
+def exists_and_is_accessible(path: Path) -> bool:
+    try:
+        return path.exists()
+    except PermissionError:
+        return False
 
 @attr.s
 class SystemPath(object):
@@ -222,7 +227,7 @@ class SystemPath(object):
                     path=p.absolute(), is_root=True, only_python=self.only_python
                 )
                 for p in path_instances
-                if p.exists()
+                if exists_and_is_accessible(p)
             }
         )
         new_instance = attr.evolve(
@@ -669,7 +674,7 @@ class SystemPath(object):
                     path=p.absolute(), is_root=True, only_python=only_python
                 )
                 for p in _path_objects
-                if p.exists()
+                if exists_and_is_accessible(p)
             }
         )
         instance = cls(

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -62,7 +62,7 @@ if MYPY_RUNNING:
     ChildType = Union[PythonFinder, "PathEntry"]
     PathType = Union[PythonFinder, "PathEntry"]
 
-def exists_and_is_accessible(path: Path) -> bool:
+def exists_and_is_accessible(path):
     try:
         return path.exists()
     except PermissionError as pe:


### PR DESCRIPTION
Fix for https://github.com/sarugaku/pythonfinder/issues/111

I'm sure there are style/standards issues specific to your codebase that will need to be adjusted here. This is just a rough first pass.