### PR TITLE
fix permissions issue on WSL

### DIFF
--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -1,11 +1,11 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function
 
+import errno
 import operator
 import os
 import stat
 import sys
-import errno
 from collections import defaultdict
 from itertools import chain
 
@@ -64,14 +64,16 @@ if MYPY_RUNNING:
     ChildType = Union[PythonFinder, "PathEntry"]
     PathType = Union[PythonFinder, "PathEntry"]
 
+
 def exists_and_is_accessible(path):
     try:
         return path.exists()
     except PermissionError as pe:
-        if pe.errno == errno.EACCES: # Permission denied
+        if pe.errno == errno.EACCES:  # Permission denied
             return False
         else:
             raise
+
 
 @attr.s
 class SystemPath(object):
@@ -238,7 +240,9 @@ class SystemPath(object):
         )
         new_instance = attr.evolve(
             new_instance,
-            path_order=[p.as_posix() for p in path_instances if p.exists()],
+            path_order=[
+                p.as_posix() for p in path_instances if exists_and_is_accessible(p)
+            ],
             paths=path_entries,
         )
         if os.name == "nt" and "windows" not in self.finders:


### PR DESCRIPTION
### Description
#111 reported a permission issue with using pythonfinder on WSL.
#112 supposedly fixed it but upon trying I kept having issues with it (see below).
I reviewed the code that was causing the crash and the supposed fix and was able to get it to work by changing a call from `p.exists()` to `exist_and_is_accessible(p)` which makes sense given the error below.

### To reproduce in WSL
```python
Python 3.8.10 (default, Nov 26 2021, 20:14:08)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pythonfinder import Finder
>>> f = Finder()
>>> f.find_python_version(3, minor=8)
/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.8) or chardet (3.0.4) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/allanlago/.local/lib/python3.8/site-packages/pythonfinder/pythonfinder.py", line 288, in find_python_version
    return self.system_path.find_python_version(
  File "/home/allanlago/.local/lib/python3.8/site-packages/pythonfinder/pythonfinder.py", line 120, in system_path
    self._system_path = self.create_system_path()
  File "/home/allanlago/.local/lib/python3.8/site-packages/pythonfinder/pythonfinder.py", line 82, in create_system_path    return pyfinder_path.SystemPath.create(
  File "/home/allanlago/.local/lib/python3.8/site-packages/pythonfinder/models/path.py", line 694, in create
    instance = instance._run_setup()
  File "/home/allanlago/.local/lib/python3.8/site-packages/pythonfinder/models/path.py", line 241, in _run_setup
    path_order=[p.as_posix() for p in path_instances if p.exists()],
  File "/home/allanlago/.local/lib/python3.8/site-packages/pythonfinder/models/path.py", line 241, in <listcomp>
    path_order=[p.as_posix() for p in path_instances if p.exists()],
  File "/usr/lib/python3.8/pathlib.py", line 1407, in exists
    self.stat()
  File "/usr/lib/python3.8/pathlib.py", line 1198, in stat
    return self._accessor.stat(self)
PermissionError: [Errno 13] Permission denied: '/mnt/c/WINDOWS/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps'
>>> import pythonfinder
>>> pythonfinder.__version__
'1.2.10'
```

After the change, all the tests still passed though I imagine I may have neglected something since the fix was very simple so please let me know of any further changes you believe are appropriate.