### PR TITLE
Optional click

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run Tests
         run: |
-          python -m pip install "tox<4" tox-gh-actions
+          python -m pip install "tox<4" tox-gh-actions click
           tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run Tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ package_data =
 install_requires =
     attrs
     cached-property
-    click
     six
     packaging
     backports.functools_lru_cache;python_version=="2.7"
@@ -56,6 +55,8 @@ exclude =
     tasks
 
 [options.extras_require]
+cli =
+    click
 tests =
     pytest
     pytest-cov

--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -6,7 +6,6 @@ import operator
 import os
 
 import six
-from click import secho
 
 from . import environment
 from .compat import lru_cache

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 envlist =
-    docs, packaging, py27, py36, py37, py38, py39, py310, coverage-report
+    docs, packaging, py37, py38, py39, py310, coverage-report
 
 [gh-actions]
 python =
-    2.7: py27
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -16,7 +14,7 @@ passenv = CI GIT_SSL_CAINFO
 setenv =
     LC_ALL = en_US.UTF-8
 deps =
-	-e .[tests]
+	-e .[tests,cli]
 commands = coverage run -m pytest
 install_command = python -m pip install {opts} {packages} --upgrade-strategy=eager
 usedevelop = True
@@ -40,7 +38,7 @@ commands =
 deps =
     twine
     build
-    -e .[tests]
+    -e .[tests,cli]
 commands =
     python setup.py sdist
     twine check dist/*


### PR DESCRIPTION
As the commit says:
    Click is only used in `__main__.py`

Hence, we can safely make it only options for the CLI.

See #78