### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ venv.bak/
 mypyhtml/
 XDG_CACHE_HOME/
 pip-wheel-metadata/
+.pyre_configuration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,24 +12,19 @@ exclude: >
   )$
 
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 22.1.0
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
     hooks:
       - id: black
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
-
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-      - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,5 @@
 exclude: >
   (?x)^(
-      \.eggs|
-      \.git|
-      \.mypy_cache|
-      \.tox|
-      \.pyre_configuration|
-      \.venv|
-      build|
-      dist|
       src/pythonfinder/_vendor/.*\.py
   )$
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,20 +3,9 @@ requires = ['setuptools>=40.8.0', 'wheel>=0.33.0']
 
 [tool.black]
 line-length = 90
-include = '\.pyi?$'
-exclude = '''
+extend-exclude = '''
 /(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.pyre_configuration
-  | \.venv
-  | _build
-  | build
-  | dist
-  | src/pythonfinder/_vendor
+  src/pythonfinder/_vendor
 )
 '''
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,12 +102,7 @@ ignore =
     # E231,E402,E501
 extend_exclude =
     docs/source/*,
-    build,
-    dist,
     tests/*,
-    *.pyc,
-    *.egg-info,
-    .cache,
     setup.py
 max-complexity=16
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,10 +100,7 @@ ignore =
     # E402: module level import not at top of file
     # E501: line too long
     # E231,E402,E501
-exclude =
-    .tox,
-    .git,
-    __pycache__,
+extend_exclude =
     docs/source/*,
     build,
     dist,
@@ -111,7 +108,6 @@ exclude =
     *.pyc,
     *.egg-info,
     .cache,
-    .eggs,
     setup.py
 max-complexity=16
 

--- a/src/pythonfinder/compat.py
+++ b/src/pythonfinder/compat.py
@@ -1,10 +1,8 @@
 # -*- coding=utf-8 -*-
 import sys
-
-from pathlib import Path
-
 from builtins import TimeoutError
 from functools import lru_cache
+from pathlib import Path
 
 
 def getpreferredencoding():

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -5,17 +5,16 @@ import os
 import re
 import subprocess
 from collections import OrderedDict
+from collections.abc import Iterable, Sequence
 from fnmatch import fnmatch
 from threading import Timer
 
 import attr
-from packaging.version import Version, InvalidVersion
+from packaging.version import InvalidVersion, Version
 
 from .compat import Path, TimeoutError, lru_cache  # noqa
 from .environment import MYPY_RUNNING, PYENV_ROOT, SUBPROCESS_TIMEOUT
 from .exceptions import InvalidPythonVersion
-
-from collections.abc import Iterable, Sequence
 
 if MYPY_RUNNING:
     from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,13 +3,12 @@
 import os
 import sys
 from collections import namedtuple
+from pathlib import Path
 
 import pytest
 
 import pythonfinder.utils
 from pythonfinder import Finder
-
-from pathlib import Path
 
 os.environ["ANSI_COLORS_DISABLED"] = "1"
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -10,11 +10,9 @@ import sys
 import tempfile
 import warnings
 from contextlib import contextmanager
-
-import click
-
 from pathlib import Path
 
+import click
 
 TRACKED_TEMPORARY_DIRECTORIES = []
 


### PR DESCRIPTION
This PR updates the existing `pre-commit` hooks to its latest version and location.

Because `pre-commit` only passes files tracked by git to the hooks some unnecessary excludes in the config of the various hooks were removed.

_Note: `flake8` reports some errors for now. Some of them are resolved in the other PRs mentioned in #133_ 

Related to #133