### PR TITLE
chore: convert type comments to type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,20 @@ repos:
       - id: pyupgrade
         args: [ --py37-plus ]
 
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-use-type-annotations
+
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
+        args: [--add-import, from __future__ import annotations]
+        exclude: |
+          (?x)(
+              ^docs/.+\.py$
+          )
 
   - repo: https://github.com/psf/black
     rev: 23.1.0
@@ -26,3 +36,4 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
+          - flake8-type-checking

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ select = C,E,F,W,B
 ignore =
     # The default ignore list:
     # E121,E123,E126,E226,E24,E704,
-    D203,F401,E123,E203,W503,E501,E402,F841,B950
+    D203,F401,E123,E203,W503,E501,E402,F841,B950,TC,TC1
     # Our additions:
     # E127: continuation line over-indented for visual indent
     # E128: continuation line under-indented for visual indent

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import codecs
 import os
 import re

--- a/src/pythonfinder/__init__.py
+++ b/src/pythonfinder/__init__.py
@@ -2,6 +2,8 @@
 # logger has no handler and warnings like this would be reported:
 #
 # > No handlers could be found for logger "pythonfinder.models.pyenv"
+from __future__ import annotations
+
 import logging
 
 from .exceptions import InvalidPythonVersion

--- a/src/pythonfinder/__main__.py
+++ b/src/pythonfinder/__main__.py
@@ -1,6 +1,8 @@
 #!env python
 
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/src/pythonfinder/cli.py
+++ b/src/pythonfinder/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 from . import __version__

--- a/src/pythonfinder/compat.py
+++ b/src/pythonfinder/compat.py
@@ -1,7 +1,4 @@
-import sys
-from builtins import TimeoutError
-from functools import lru_cache
-from pathlib import Path
+from __future__ import annotations
 
 
 def getpreferredencoding():

--- a/src/pythonfinder/environment.py
+++ b/src/pythonfinder/environment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import sys

--- a/src/pythonfinder/exceptions.py
+++ b/src/pythonfinder/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class InvalidPythonVersion(Exception):
     """Raised when parsing an invalid python version"""
 

--- a/src/pythonfinder/models/__init__.py
+++ b/src/pythonfinder/models/__init__.py
@@ -1,8 +1,5 @@
-import abc
-import operator
-from itertools import chain
+from __future__ import annotations
 
-from ..utils import KNOWN_EXTS, unnest
 from .path import SystemPath
 from .python import PythonVersion
 from .windows import WindowsFinder

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,4 +1,5 @@
-import datetime
+from __future__ import annotations
+
 import os
 import pathlib
 import re

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path
@@ -6,7 +8,7 @@ from pathlib import Path
 import invoke
 from parver import Version
 
-from .vendoring import drop_dir, remove_all
+from .vendoring import drop_dir
 
 TASK_NAME = "RELEASE"
 

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -1,6 +1,7 @@
 # Taken from pip also
 """"Vendoring script, python 3.5 needed"""
-import os
+from __future__ import annotations
+
 import re
 import shutil
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import importlib
 import os
 import shutil
 import subprocess
 import sys
 from collections import namedtuple
+from pathlib import Path
 
 import click
 import click.testing
@@ -20,12 +23,6 @@ from .testutils import (
     temp_environ,
     yield_versions,
 )
-
-if sys.version_info[:2] < (3, 5):
-    from pathlib2 import Path
-else:
-    from pathlib import Path
-
 
 pythoninfo = namedtuple("PythonVersion", ["name", "version", "path", "arch"])
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import importlib
 import os

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import os
-import sys
 from collections import namedtuple
 from pathlib import Path
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import atexit
 import itertools
 import os
 import shutil
 import stat
-import sys
 import tempfile
 import warnings
 from contextlib import contextmanager
@@ -14,8 +15,7 @@ import click
 TRACKED_TEMPORARY_DIRECTORIES = []
 
 
-def set_write_bit(fn):
-    # type: (str) -> None
+def set_write_bit(fn: str) -> None:
     """
     Set read-write permissions for the current user on the target path.  Fail silently
     if the path doesn't exist.
@@ -84,8 +84,7 @@ def temp_environ():
         os.environ.update(environ)
 
 
-def normalize_path(path):
-    # type: (AnyStr) -> AnyStr
+def normalize_path(path: AnyStr) -> AnyStr:
     """
     Return a case-normalized absolute variable-expanded path.
 
@@ -111,8 +110,7 @@ def normalize_path(path):
     return os.path.normpath(os.path.normcase(path))
 
 
-def is_in_path(path, parent):
-    # type: (AnyStr, AnyStr) -> bool
+def is_in_path(path: AnyStr, parent: AnyStr) -> bool:
     """
     Determine if the provided full path is in the given parent root.
 


### PR DESCRIPTION
This PR converts type comment to type annotation with the help of [com2ann](https://pypi.org/project/com2ann/).

Also a `py.typed` file is added according to [PEP-561](https://peps.python.org/pep-0561/). I wasn't able to edit `setup.cfg` to include this file into the distribution files. So any help here is appreciated :smile: 

Based on https://github.com/sarugaku/pythonfinder/pull/131

Related to #133 