### PR TITLE
chore(pre-commit): replace several linter by ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,6 @@ exclude: >
   )$
 
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [ --py37-plus ]
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -20,33 +14,14 @@ repos:
     rev: v1.9.0
     hooks:
       - id: python-use-type-annotations
-      - id: python-check-blanket-noqa
 
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.263
     hooks:
-      - id: yesqa
-        additional_dependencies: &flake8_deps
-          - flake8-bugbear
-          - flake8-type-checking
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: [--add-import, from __future__ import annotations]
-        exclude: |
-          (?x)(
-              ^docs/.+\.py$
-          )
+      - id: ruff
+        args: [ --exit-non-zero-on-fix ]
 
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
       - id: black
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: *flake8_deps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ exclude: >
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-use-type-annotations
 
@@ -22,6 +22,6 @@ repos:
         args: [ --exit-non-zero-on-fix ]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,48 @@ extend-exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
-atomic = true
-filter_files = true
-known_first_party = ["pythonfinder"]
+[tool.ruff]
+target-version = "py37"
+fix = true
+line-length = 90
+select = [
+  "B",   # flake8-bugbear
+  "E",   # pycodestyle (flake8)
+  "F",   # pyflakes (flake8)
+  "I",   # isort
+  "PGH", # pygrep-hooks
+  "RUF", # Ruff u.a. yesqa
+  "TCH", # flake8-type-checking
+  "UP",  # pyupgrade
+  "W",   # pycodestyle (flake8)
+]
+ignore = [
+    "B904",    # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+    "E501",    # line too long (flake8)
+    "PGH003",  # Use specific rule codes when ignoring type issues
+]
+unfixable = [
+    "F841",   # Local variable {x} is assigned to but never used (flake8)
+]
+[tool.ruff.per-file-ignores]
+"__init__.py" = [
+    "F401",  # module imported but unused (flake8)
+    "F403",  # ‘from module import *’ used; unable to detect undefined names (flake8)
+]
+"docs/*" = [
+  "I",
+]
+
+[tool.ruff.flake8-type-checking]
+runtime-evaluated-base-classes = [
+  "pydantic.BaseModel",
+  "pythonfinder.models.common.FinderBaseModel",
+  "pythonfinder.models.mixins.PathEntry",
+]
+
+[tool.ruff.isort]
+known-first-party = ["pythonfinder"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.towncrier]
 package = "pythonfinder"

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,41 +84,6 @@ filterwarnings =
 [bdist_wheel]
 universal = 1
 
-[flake8]
-max-line-length = 90
-select = C,E,F,W,B
-ignore =
-    # The default ignore list:
-    # E121,E123,E126,E226,E24,E704,
-    D203,F401,E123,E203,W503,E501,E402,F841,B950,TC,TC1
-    # Our additions:
-    # E127: continuation line over-indented for visual indent
-    # E128: continuation line under-indented for visual indent
-    # E129: visually indented line with same indent as next logical line
-    # E222: multiple spaces after operator
-    # E231: missing whitespace after ','
-    # E402: module level import not at top of file
-    # E501: line too long
-    # E231,E402,E501
-extend_exclude =
-    docs/source/*,
-    tests/*,
-    setup.py
-max-complexity=16
-
-[isort]
-atomic = true
-not_skip = __init__.py
-skip = src/pythonfinder/_vendor
-line_length = 90
-indent = '    '
-multi_line_output = 3
-known_third_party = cached_property,click,invoke,packaging,parver,pydantic,pytest,requests,setuptools,six,towncrier
-known_first_party = pythonfinder,tests
-combine_as_imports=True
-include_trailing_comma = True
-force_grid_wrap=0
-
 [mypy]
 ignore_missing_imports=true
 follow_imports=skip

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import codecs
 import os
 import re
-import sys
 
-from setuptools import Command, find_packages, setup
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/pythonfinder/__init__.py
+++ b/src/pythonfinder/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .exceptions import InvalidPythonVersion
 from .models import SystemPath
 from .pythonfinder import Finder

--- a/src/pythonfinder/cli.py
+++ b/src/pythonfinder/cli.py
@@ -60,7 +60,7 @@ def cli(
                 comes_from_path = getattr(comes_from, "path", found.path)
             else:
                 comes_from_path = found.path
-            arch = getattr(py, "architecture", None)
+
             click.secho("Found python at the following locations:", fg="green")
             click.secho(
                 "{py.name!s}: {py.version!s} ({py.architecture!s}) @ {comes_from!s}".format(

--- a/src/pythonfinder/models/__init__.py
+++ b/src/pythonfinder/models/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from .path import SystemPath
 from .python import PythonVersion

--- a/src/pythonfinder/models/common.py
+++ b/src/pythonfinder/models/common.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, Extra
 
 
 class FinderBaseModel(BaseModel):
-    def __setattr__(self, name, value):  # noqa: C901 (ignore complexity)
+    def __setattr__(self, name, value):
         private_attributes = {
-            field_name for field_name in self.__annotations__ if field_name.startswith("_")
+            field_name
+            for field_name in self.__annotations__
+            if field_name.startswith("_")
         }
 
         if name in private_attributes or name in self.__fields__:

--- a/src/pythonfinder/pythonfinder.py
+++ b/src/pythonfinder/pythonfinder.py
@@ -1,18 +1,16 @@
-import operator
-import os
-from typing import Any, Dict, List, Optional, Union
+from __future__ import annotations
 
-from pydantic import BaseModel
+import operator
+from typing import Any, Optional
 
 from .exceptions import InvalidPythonVersion
-from .utils import Iterable, version_re
+from .models.common import FinderBaseModel
 from .models.path import PathEntry, SystemPath
 from .models.python import PythonVersion
-from .models.common import FinderBaseModel
+from .utils import Iterable, version_re
 
 
 class Finder(FinderBaseModel):
-
     path_prepend: Optional[str] = None
     system: bool = False
     global_search: bool = True
@@ -41,20 +39,19 @@ class Finder(FinderBaseModel):
             ignore_unsupported=self.ignore_unsupported,
         )
 
-    def which(self, exe) -> Optional[PathEntry]:
+    def which(self, exe) -> PathEntry | None:
         return self.system_path.which(exe)
 
     @classmethod
     def parse_major(
         cls,
-        major: Optional[str],
-        minor: Optional[int]=None,
-        patch: Optional[int]=None,
-        pre: Optional[bool]=None,
-        dev: Optional[bool]=None,
-        arch: Optional[str]=None,
-    ) -> Dict[str, Any]:
-
+        major: str | None,
+        minor: int | None = None,
+        patch: int | None = None,
+        pre: bool | None = None,
+        dev: bool | None = None,
+        arch: str | None = None,
+    ) -> dict[str, Any]:
         major_is_str = major and isinstance(major, str)
         is_num = (
             major
@@ -70,7 +67,7 @@ class Finder(FinderBaseModel):
         )
         name = None
         if major and major_has_arch:
-            orig_string = "{0!s}".format(major)
+            orig_string = f"{major!s}"
             major, _, arch = major.rpartition("-")
             if arch:
                 arch = arch.lower().lstrip("x").replace("bit", "")
@@ -78,12 +75,12 @@ class Finder(FinderBaseModel):
                     major = orig_string
                     arch = None
                 else:
-                    arch = "{0}bit".format(arch)
+                    arch = f"{arch}bit"
             try:
                 version_dict = PythonVersion.parse(major)
             except (ValueError, InvalidPythonVersion):
                 if name is None:
-                    name = "{0!s}".format(major)
+                    name = f"{major!s}"
                     major = None
                 version_dict = {}
         elif major and major[0].isalpha():
@@ -125,15 +122,15 @@ class Finder(FinderBaseModel):
 
     def find_python_version(
         self,
-        major: Optional[Union[str, int]] = None,
-        minor: Optional[int] = None,
-        patch: Optional[int] = None,
-        pre: Optional[bool] = None,
-        dev: Optional[bool] = None,
-        arch: Optional[str] = None,
-        name: Optional[str] = None,
+        major: str | int | None = None,
+        minor: int | None = None,
+        patch: int | None = None,
+        pre: bool | None = None,
+        dev: bool | None = None,
+        arch: str | None = None,
+        name: str | None = None,
         sort_by_path: bool = False,
-    ) -> Optional[PathEntry]:
+    ) -> PathEntry | None:
         """
         Find the python version which corresponds most closely to the version requested.
 
@@ -184,14 +181,14 @@ class Finder(FinderBaseModel):
 
     def find_all_python_versions(
         self,
-        major: Optional[Union[str, int]] = None,
-        minor: Optional[int] = None,
-        patch: Optional[int] = None,
-        pre: Optional[bool] = None,
-        dev: Optional[bool] = None,
-        arch: Optional[str] = None,
-        name: Optional[str] = None,
-    ) -> List[PathEntry]:
+        major: str | int | None = None,
+        minor: int | None = None,
+        patch: int | None = None,
+        pre: bool | None = None,
+        dev: bool | None = None,
+        arch: str | None = None,
+        name: str | None = None,
+    ) -> list[PathEntry]:
         version_sort = operator.attrgetter("as_python.version_sort")
         python_version_dict = getattr(self.system_path, "python_version_dict", {})
         if python_version_dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,9 @@ import sys
 from collections import namedtuple
 from pathlib import Path
 
-import click
-import click.testing
 import pytest
 
 import pythonfinder
-from pythonfinder import environment
 
 from .testutils import (
     cd,
@@ -103,7 +100,6 @@ def no_pyenv_root_envvar(monkeypatch):
 
 @pytest.fixture
 def isolated_envdir(create_tmpdir):
-    runner = click.testing.CliRunner()
     fake_root_path = create_tmpdir()
     fake_root = fake_root_path.as_posix()
     set_write_bit(fake_root)
@@ -157,7 +153,7 @@ def setup_plugin(name):
     this = Path(__file__).absolute().parent
     plugin_dir = this / "test_artifacts" / name
     plugin_uri = plugin_dir.as_uri()
-    if not "file:///" in plugin_uri and "file:/" in plugin_uri:
+    if "file:///" not in plugin_uri and "file:/" in plugin_uri:
         plugin_uri = plugin_uri.replace("file:/", "file:///")
     out = subprocess.check_output(["git", "clone", plugin_uri, Path(target).as_posix()])
     print(out, file=sys.stderr)
@@ -230,7 +226,7 @@ def setup_asdf(home_dir):
 
 @pytest.fixture
 def setup_pythons(isolated_envdir, monkeypatch):
-    with monkeypatch.context() as m:
+    with monkeypatch.context():
         setup_plugin("asdf")
         setup_plugin("pyenv")
         asdf_dict = setup_asdf(isolated_envdir)
@@ -306,7 +302,7 @@ def get_windows_python_versions():
     versions = []
     for line in out.splitlines():
         line = line.strip()
-        if line and not "Installed Pythons found" in line:
+        if line and "Installed Pythons found" not in line:
             version, path = line.split("\t")
             version = version.strip().lstrip("-")
             path = normalize_path(path.strip().strip('"'))

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,23 +1,14 @@
 from __future__ import annotations
 
 import functools
-import importlib
 import os
 import sys
+
 import pytest
 from packaging.version import Version
 
-import pythonfinder
-from pythonfinder import utils, environment
-from pythonfinder.pythonfinder import Finder
+from pythonfinder import utils
 from pythonfinder.models.python import PythonFinder, PythonVersion
-
-from .testutils import (
-    is_in_ospath,
-    normalize_path,
-    normalized_match,
-    print_python_versions,
-)
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="Must run on Python 3")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,13 +17,7 @@ pythoninfo = namedtuple("PythonVersion", ["version", "path", "arch"])
 def _get_python_versions():
     finder = Finder(global_search=True, system=False, ignore_unsupported=True)
     pythons = finder.find_all_python_versions()
-    for v in pythons:
-        py = v.py_version
-        comes_from = getattr(py, "comes_from", None)
-        if comes_from is not None:
-            comes_from_path = getattr(comes_from, "path", v.path)
-        else:
-            comes_from_path = v.path
+
     return sorted(list(pythons))
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -9,6 +9,7 @@ import tempfile
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
+from typing import AnyStr
 
 import click
 


### PR DESCRIPTION
This PR replaces several linter by ruff. `ruff` is a very fast linter and autoformatter.

Some unused variables were found by ruff. So I removed them.

I would suggest to register the repo on https://pre-commit.ci now, to run `pre-commit` in every PR.