### PR TITLE
Fix edge case with windows gitbash and environment variables having backslash

### DIFF
--- a/news/138.bugfix.rst
+++ b/news/138.bugfix.rst
@@ -1,0 +1,1 @@
+Fix edge case with windows git bash and environment variables having backslash.

--- a/src/pythonfinder/environment.py
+++ b/src/pythonfinder/environment.py
@@ -17,14 +17,27 @@ def is_type_checking():
     return TYPE_CHECKING
 
 
+def possibly_convert_to_windows_style_path(path):
+    if not isinstance(path, str):
+        path = str(path)
+    # Check if the path is in Unix-style (Git Bash)
+    if os.name == 'nt':
+        if path.startswith('/'):
+            drive, tail = re.match(r"^/([a-zA-Z])/(.*)", path).groups()
+            revised_path = drive.upper() + ":\\" + tail.replace('/', '\\')
+            return revised_path
+        elif path.startswith('\\'):
+            drive, tail = re.match(r"^\\([a-zA-Z])\\(.*)", path).groups()
+            revised_path = drive.upper() + ":\\" + tail.replace('\\', '\\')
+            return revised_path
+
+    return path
+
+
 PYENV_ROOT = os.path.expanduser(
     os.path.expandvars(os.environ.get("PYENV_ROOT", "~/.pyenv"))
 )
-# Check if the path is in Unix-style (Git Bash)
-if PYENV_ROOT.startswith('/') and os.name == 'nt':
-    # Convert to Windows-style path
-    drive, tail = re.match(r"^/([a-zA-Z])/(.*)", PYENV_ROOT).groups()
-    PYENV_ROOT = drive.upper() + ":\\" + tail.replace('/', '\\')
+PYENV_ROOT = possibly_convert_to_windows_style_path(PYENV_ROOT)
 PYENV_INSTALLED = shutil.which("pyenv") != None
 ASDF_DATA_DIR = os.path.expanduser(
     os.path.expandvars(os.environ.get("ASDF_DATA_DIR", "~/.asdf"))

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -176,10 +176,7 @@ class SystemPath(FinderBaseModel):
         if self.global_search and "PATH" in os.environ:
             path_order = path_order + os.environ["PATH"].split(os.pathsep)
         path_order = list(dedup(path_order))
-        path_instances = [
-            ensure_path(p.strip('"'))
-            for p in path_order
-        ]
+        path_instances = [ensure_path(p.strip('"')) for p in path_order]
         self.paths.update(
             {
                 p.as_posix(): PathEntry.create(
@@ -206,9 +203,9 @@ class SystemPath(FinderBaseModel):
         else:
             bin_dir = "bin"
         if venv and (self.system or self.global_search):
-            path_order = [(p / bin_dir).as_posix(), *self.path_order]
+            path_order = [(venv / bin_dir).as_posix(), *self.path_order]
             self.path_order = path_order
-            self.paths[p] = self.get_path(p.joinpath(bin_dir))
+            self.paths[venv] = self.get_path(venv.joinpath(bin_dir))
         if self.system:
             syspath = Path(sys.executable)
             syspath_bin = syspath.parent

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -199,12 +199,13 @@ class SystemPath(FinderBaseModel):
         if self.check_for_asdf() and "asdf" not in self.finders:
             self._setup_asdf()
         venv = os.environ.get("VIRTUAL_ENV")
+        if venv:
+            venv = ensure_path(venv)
         if os.name == "nt":
             bin_dir = "Scripts"
         else:
             bin_dir = "bin"
         if venv and (self.system or self.global_search):
-            p = ensure_path(venv)
             path_order = [(p / bin_dir).as_posix(), *self.path_order]
             self.path_order = path_order
             self.paths[p] = self.get_path(p.joinpath(bin_dir))

--- a/src/pythonfinder/utils.py
+++ b/src/pythonfinder/utils.py
@@ -13,7 +13,7 @@ from typing import Any, Iterator
 
 from packaging.version import InvalidVersion, Version
 
-from .environment import PYENV_ROOT
+from .environment import PYENV_ROOT, possibly_convert_to_windows_style_path
 from .exceptions import InvalidPythonVersion
 
 version_re_str = (
@@ -234,7 +234,7 @@ def ensure_path(path: Path | str) -> Path:
     :type path: str or :class:`~pathlib.Path`
     :return: A fully expanded Path object.
     """
-
+    path = possibly_convert_to_windows_style_path(path)
     if isinstance(path, Path):
         return path
     path = Path(os.path.expandvars(path))


### PR DESCRIPTION
Follow-up fix to edge case of env vars in windows that have backslash in git shell. 