### PR TITLE
Fix edge case from refactor to pydantic

### DIFF
--- a/news/139.bugfix.rst
+++ b/news/139.bugfix.rst
@@ -1,0 +1,1 @@
+Fix edge case from refactor to pydantic -- only search for any python version when a specific version was not requested.

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -462,14 +462,14 @@ class SystemPath(FinderBaseModel):
                 found_version = sub_finder(path)
                 if found_version:
                     return found_version
-            if alternate_sub_finder:
+            if name and not (minor or patch or pre or dev or arch or major):
                 for path in paths:
                     found_version = alternate_sub_finder(path)
                     if found_version:
                         return found_version
 
         ver = next(iter(self.get_pythons(sub_finder)), None)
-        if not ver and alternate_sub_finder is not None:
+        if not ver and name and not (minor or patch or pre or dev or arch or major):
             ver = next(iter(self.get_pythons(alternate_sub_finder)), None)
 
         if ver:


### PR DESCRIPTION
Fix edge case from refactor to pydantic -- only search for any python version when a specific version was not requested.