### PR TITLE
Extend support to Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,3 @@ name = "pypi"
 
 [packages]
 pythonfinder = {editable = true, extras = ["dev", "tests"], path = "."}
-
-[dev-packages]
-
-[requires]
-python_version = "3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Build Tools
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    docs, packaging, py37, py38, py39, py310, coverage-report
+    docs, packaging, py37, py38, py39, py310, py311, coverage-report
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 passenv = CI GIT_SSL_CAINFO


### PR DESCRIPTION
Extend support to Python 3.11 as we have no problem being compatible with Python 3.11, and downstream Pipenv supports Python 3.11 with no significant issues using the code in this repo.