### PR TITLE
Drop Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -32,9 +31,8 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    "cached-property; python_version < \"3.8\"",
     "packaging>=22.0",
     "pydantic>=1.10.7,<2",
 ]
@@ -98,13 +96,13 @@ filterwarnings = [
 ignore_missing_imports = true
 follow_imports = "skip"
 html_report = "mypyhtml"
-python_version = "3.7"
+python_version = "3.8"
 
 [tool.black]
 line-length = 90
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 fix = true
 line-length = 90
 select = [

--- a/src/pythonfinder/models/path.py
+++ b/src/pythonfinder/models/path.py
@@ -5,6 +5,7 @@ import operator
 import os
 import sys
 from collections import ChainMap, defaultdict
+from functools import cached_property
 from itertools import chain
 from pathlib import Path
 from typing import (
@@ -19,10 +20,6 @@ from typing import (
     Union,
 )
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from cached_property import cached_property
 from pydantic import Field, root_validator
 
 from ..environment import (

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    docs, packaging, py37, py38, py39, py310, py311, coverage-report
+    docs, packaging, py38, py39, py310, py311, coverage-report
 
 [gh-actions]
 python =


### PR DESCRIPTION
Python 3.7 reached EOL, so let's drop it.