### PR TITLE
move pytest options from pytest config to tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
 cli = ["click"]
 tests = [
     "pytest",
-    "pytest-cov",
     "pytest-timeout",
     "coverage[toml]",
 ]
@@ -81,7 +80,7 @@ exclude = [
 namespaces = false
 
 [tool.pytest.ini_options]
-addopts = "-ra --timeout 300 --cov"
+addopts = "-ra"
 testpaths = ["tests/"]
 norecursedirs = [".*", "build", "dist", "news", "tasks", "docs"]
 markers = [

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
     LC_ALL = en_US.UTF-8
 deps =
 	-e .[tests,cli]
-commands = coverage run -m pytest
+commands = coverage run -m pytest --timeout 300
 install_command = python -m pip install {opts} {packages} --upgrade-strategy=eager
 usedevelop = True
 


### PR DESCRIPTION
The --cov option was useless, since tox already uses `coverage run` instead. While we are at it, we can also drop pytest-cov from the test dependencies. One less wheel for tox to download and install.

The timeout option is moved to tox.

Both of these options add additional dependencies for running `pytest` outside of tox, which may sometimes be desired if you really know what you are doing. There is no way to disable them other than by patching out the addopts configuration. Best to specify this only in tox, which is designed to set up the appropriate environments already.

Bug: https://bugs.gentoo.org/922192