### PR TITLE
Remove useless shebang from main.py

### DIFF
--- a/src/pythonfinder/main.py
+++ b/src/pythonfinder/main.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
This solves the following issue:
```
$ src/pythonfinder/main.py
Traceback (most recent call last):
  File "/data/builds/pythonfinder/src/pythonfinder/main.py", line 8, in <module>
    from .cli import cli
ImportError: attempted relative import with no known parent package
$
```
by dropping the shebang and removing the execute mode from the file.