### PR TITLE
fix: resolve full patch version from py-launcher executable

### DIFF
--- a/news/158.bugfix.rst
+++ b/news/158.bugfix.rst
@@ -1,0 +1,15 @@
+Fix full-version matching for Python installations discovered via the Windows
+py launcher.
+
+``py --list-paths`` only reports ``major.minor`` (e.g. ``3.11``), so
+``PyLauncherFinder`` was storing ``patch=None`` for every entry.  Callers that
+searched for a specific full version such as ``3.11.9`` (e.g. from
+``python_full_version`` in a Pipfile) received no match because
+``matches(patch=9)`` evaluated ``None == 9 → False``.
+
+The finder now queries each discovered executable for its real version string
+(e.g. ``3.11.9``) via ``get_python_version()`` after the py-launcher lookup,
+so that full-version searches succeed.  If the executable cannot be queried the
+code falls back gracefully to the ``major.minor`` string reported by the py
+launcher.
+

--- a/src/pythonfinder/finders/py_launcher_finder.py
+++ b/src/pythonfinder/finders/py_launcher_finder.py
@@ -92,7 +92,10 @@ class PyLauncherFinder(BaseFinder):
         Create a PythonInfo object from py launcher information.
 
         Args:
-            version: The Python version (e.g. "3.11").
+            version: The Python version reported by the py launcher (e.g. "3.11").
+                     This is typically only major.minor; the full patch version is
+                     resolved by querying the executable so that searches for a
+                     specific full version (e.g. "3.11.9") succeed.
             path: The path to the Python executable.
             is_default: "*" if this is the default version, "" otherwise.
 
@@ -102,13 +105,29 @@ class PyLauncherFinder(BaseFinder):
         if not path or not os.path.exists(path):
             return None
 
-        # Parse the version
+        # Parse the version reported by the py launcher (usually major.minor only).
         try:
             version_data = parse_python_version(version)
         except InvalidPythonVersion:
             if not self.ignore_unsupported:
                 raise
             return None
+
+        # `py --list-paths` only reports major.minor (e.g. "3.11").  Resolve the
+        # real patch version by querying the executable so that callers searching
+        # for a full version string like "3.11.9" can match correctly.
+        if version_data.get("patch") is None:
+            try:
+                from ..utils.version_utils import get_python_version
+
+                full_version = get_python_version(path)
+                full_version_data = parse_python_version(full_version)
+                version_data = full_version_data
+                version = full_version
+            except Exception:
+                # If we can't run the executable, fall back to the major.minor
+                # version string provided by the py launcher.
+                pass
 
         # Create the PythonInfo object
         return PythonInfo(


### PR DESCRIPTION
## Problem

`py --list-paths` only reports `major.minor` (e.g. `3.11`), so `PyLauncherFinder` stored `patch=None` for every entry it created.

Callers that searched for a specific **full** version string — such as `3.11.9` coming from `python_full_version = "3.11.9"` in a Pipfile — received no match because `PythonInfo.matches(patch=9)` evaluated `None == 9 → False`, even when the exact Python version was installed and visible to `py --list-paths`.

This is the underlying cause of [pypa/pipenv#5893](https://github.com/pypa/pipenv/issues/5893).

## Fix

After parsing the `major.minor` version string from the py launcher, query the discovered executable for its real version string (e.g. `3.11.9`) via `get_python_version()`. The resolved version populates all fields of `PythonInfo` — including `patch` — so that full-version lookups succeed.

If the executable cannot be queried (e.g. permission error, timeout), the code falls back gracefully to the `major.minor` string provided by the py launcher, preserving the existing behaviour.

## Behaviour before / after

| Query | Python in PATH? | Before | After |
|---|---|---|---|
| `find_python_version("3.11")` | No (py-launcher only) | ✅ | ✅ |
| `find_python_version("3.11.9")` | No (py-launcher only) | ❌ `patch=None` mismatch | ✅ |
| `find_python_version("3.11.9")` | Yes | ✅ | ✅ |


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author